### PR TITLE
Fixed out of memory when uploading big file

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/upload/MonitoredMultipartFile.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/upload/MonitoredMultipartFile.java
@@ -2,6 +2,7 @@ package org.airsonic.player.upload;
 
 import com.google.re2j.Pattern;
 import org.apache.commons.io.FilenameUtils;
+import org.springframework.util.FileCopyUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
@@ -67,10 +68,9 @@ public class MonitoredMultipartFile implements MultipartFile {
 
     @Override
     public void transferTo(File dest) throws IOException, IllegalStateException {
-        try (
-            FileOutputStream fos = new FileOutputStream(dest);
-            MonitoredOutputStream monitoredOutputStream = new MonitoredOutputStream(fos, listener)) {
-            monitoredOutputStream.write(file.getBytes());
-        }
+        InputStream inputStream = file.getInputStream();
+        FileOutputStream outputStream = new FileOutputStream(dest);
+        MonitoredOutputStream monitoredOutputStream = new MonitoredOutputStream(outputStream, listener);
+        FileCopyUtils.copy(inputStream, monitoredOutputStream);
     }
 }


### PR DESCRIPTION
Closes #259.

Tests with 2GB Zip file.
```
spring.servlet.multipart.max-file-size=3GB
spring.servlet.multipart.max-request-size=3GB
```

Before patch:
![Screenshot 2023-08-05 155414](https://github.com/kagemomiji/airsonic-advanced/assets/127358482/dafd16d1-589e-4ca6-ad8c-dc44fe75062d)
![Screenshot 2023-08-05 155640](https://github.com/kagemomiji/airsonic-advanced/assets/127358482/479cb4e7-b5e8-4818-b19d-5b5447f272b9)

After patch:
![Screenshot 2023-08-05 155733](https://github.com/kagemomiji/airsonic-advanced/assets/127358482/caea52d8-47f9-44b3-8fa0-de410e752bc7)
![Screenshot 2023-08-05 155849](https://github.com/kagemomiji/airsonic-advanced/assets/127358482/8bc319ea-b8ee-4b9d-bd52-bdc6cd5bb10f)
