### PR TITLE
#129 ignore empty query at building lucene query

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/JAXBWriter.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/JAXBWriter.java
@@ -63,6 +63,8 @@ public class JAXBWriter {
     private final DatatypeFactory datatypeFactory;
     private static final String restProtocolVersion = parseRESTProtocolVersion();
 
+    private final String SERVER_TYPE = "Airsonic-Advanced";
+
     public JAXBWriter() {
         try {
             jaxbContext = JAXBContext.newInstance(Response.class);
@@ -116,6 +118,7 @@ public class JAXBWriter {
         Response response = new ObjectFactory().createResponse();
         response.setStatus(ok ? ResponseStatus.OK : ResponseStatus.FAILED);
         response.setVersion(restProtocolVersion);
+        response.setType(SERVER_TYPE);
         return response;
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
@@ -767,6 +767,8 @@ public class SubsonicRESTController {
         SearchResult3 searchResult = new SearchResult3();
 
         String query = request.getParameter("query");
+        // replace empty string with null
+        query = "\"\"".equals(query) ? null : query;
         SearchCriteria criteria = new SearchCriteria();
         criteria.setQuery(StringUtils.trimToEmpty(query));
         criteria.setCount(getIntParameter(request, "artistCount", 20));

--- a/airsonic-main/src/main/java/org/airsonic/player/service/search/QueryFactory.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/search/QueryFactory.java
@@ -37,6 +37,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -172,8 +173,11 @@ public class QueryFactory {
 
         BooleanQuery.Builder mainQuery = new BooleanQuery.Builder();
 
-        Query multiFieldQuery = createMultiFieldWildQuery(indexType.getFields(), criteria.getQuery(), indexType);
-        mainQuery.add(multiFieldQuery, Occur.MUST);
+        if (StringUtils.hasText(criteria.getQuery())) {
+            Query multiFieldQuery = createMultiFieldWildQuery(indexType.getFields(), criteria.getQuery(), indexType);
+            mainQuery.add(multiFieldQuery, Occur.MUST);
+        }
+
 
         boolean isId3 = indexType == IndexType.ALBUM_ID3 || indexType == IndexType.ARTIST_ID3;
         Query folderQuery = toFolderQuery.apply(isId3, musicFolders);

--- a/integration-test/src/test/resources/blobs/ping/missing-auth.xml
+++ b/integration-test/src/test/resources/blobs/ping/missing-auth.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<subsonic-response xmlns="http://subsonic.org/restapi" status="failed" version="1.15.0">
+<subsonic-response xmlns="http://subsonic.org/restapi" status="failed" version="1.15.0" type="Airsonic-Advanced">
     <error code="10" message="Required parameter is missing."/>
 </subsonic-response>

--- a/integration-test/src/test/resources/blobs/ping/ok.xml
+++ b/integration-test/src/test/resources/blobs/ping/ok.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<subsonic-response xmlns="http://subsonic.org/restapi" status="ok" version="1.15.0"/>
+<subsonic-response xmlns="http://subsonic.org/restapi" status="ok" version="1.15.0" type="Airsonic-Advanced"/>

--- a/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
+++ b/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
@@ -56,6 +56,7 @@
         </xs:choice>
         <xs:attribute name="status" type="sub:ResponseStatus" use="required"/>
         <xs:attribute name="version" type="sub:Version" use="required"/>
+        <xs:attribute name="type" type="xs:string" use="required"/>
     </xs:complexType>
 
     <xs:simpleType name="ResponseStatus">


### PR DESCRIPTION
To support symfonium, support empty query at the search3 endpoint.

Fix #129