### PR TITLE
fixed typo search.tag spelled as serach.tag. Resolves #677

### DIFF
--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
@@ -202,7 +202,7 @@ search.hits.albums=Albums
 search.hits.songs=Songs
 search.hits.videos=Videos
 search.folder=Folder
-serach.tag=Tag
+search.tag=Tag
 
 gettingStarted.title=Getting started
 gettingStarted.text=<p>Welcome to Airsonic. Follow the basic steps below.<br> Click the Home button in the toolbar above to return here.</p> <p>More information to be found in the <a href="https://airsonic.github.io/docs/first-start/" target="_blank"><b>first start</b></a> guide.</p>


### PR DESCRIPTION
search.tag was misspelled as serach.tag in en localization. Fixes issue #677 