### PR TITLE
Bump up spring boot to 3.4

### DIFF
--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -411,7 +411,7 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-spring-boot-autoconfigure</artifactId>
-            <version>4.0.5</version>
+            <version>${cxf.version}</version>
         </dependency>
 
         <dependency>

--- a/airsonic-main/src/main/java/org/airsonic/player/security/CustomLDAPAuthenticatorPostProcessor.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/CustomLDAPAuthenticatorPostProcessor.java
@@ -10,7 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.config.annotation.ObjectPostProcessor;
+import org.springframework.security.config.ObjectPostProcessor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;

--- a/airsonic-main/src/main/java/org/airsonic/player/service/podcast/PodcastIndexService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/podcast/PodcastIndexService.java
@@ -53,7 +53,7 @@ public class PodcastIndexService {
             if (decoded != null) {
                 HttpUriRequest req = createRequest(
                         UriComponentsBuilder
-                                .fromHttpUrl(StringUtils.isBlank(userSettings.getPodcastIndexUrl()) ? DEFAULT_URL
+                                .fromUriString(StringUtils.isBlank(userSettings.getPodcastIndexUrl()) ? DEFAULT_URL
                                         : userSettings.getPodcastIndexUrl())
                                 .queryParam("q", search).toUriString(),
                         cred.getAppUsername(), decoded);

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/AvatarControllerTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/AvatarControllerTest.java
@@ -33,9 +33,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -67,10 +67,10 @@ public class AvatarControllerTest {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private UserSettings userSettings;
 
-    @MockBean
+    @MockitoBean
     private PersonalSettingsService personalSettingsService;
 
     @Mock

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/AvatarUploadControllerTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/AvatarUploadControllerTest.java
@@ -17,11 +17,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -55,10 +55,10 @@ public class AvatarUploadControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private PersonalSettingsService personalSettingsService;
 
-    @MockBean
+    @MockitoBean
     private SecurityService securityService;
 
     @TempDir

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/CoverArtControllerTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/CoverArtControllerTest.java
@@ -38,9 +38,9 @@ import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -71,7 +71,7 @@ public class CoverArtControllerTest {
     @Autowired
     private MockMvc mvc;
 
-    @SpyBean
+    @MockitoSpyBean
     private CoverArtCreateService coverArtService;
 
     @Mock

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/ImportPlaylistControllerTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/ImportPlaylistControllerTest.java
@@ -12,10 +12,10 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -54,10 +54,10 @@ public class ImportPlaylistControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private SecurityService securityService;
 
-    @MockBean
+    @MockitoBean
     private PlaylistFileService playlistFileService;
 
     @TempDir

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/PodcastEpisodesControllerTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/PodcastEpisodesControllerTest.java
@@ -36,8 +36,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.nio.file.Path;
@@ -65,10 +65,10 @@ public class PodcastEpisodesControllerTest {
     @TempDir
     private static Path tempDir;
 
-    @MockBean
+    @MockitoBean
     private PodcastPersistenceService podcastService;
 
-    @MockBean
+    @MockitoBean
     private PodcastDownloadClient podcastDownloadClient;
 
     @Mock

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/UploadControllerTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/UploadControllerTest.java
@@ -43,12 +43,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -85,19 +85,19 @@ class UploadControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private StatusService statusService;
 
-    @MockBean
+    @MockitoBean
     private PlayerService playerService;
 
-    @MockBean
+    @MockitoBean
     private SettingsService settingsService;
 
-    @MockBean
+    @MockitoBean
     private SimpMessagingTemplate brokerTemplate;
 
-    @MockBean
+    @MockitoBean
     private SecurityService securityService;
 
     @TempDir

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/UserSettingsControllerTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/UserSettingsControllerTest.java
@@ -21,8 +21,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.nio.file.Path;
 import java.util.Collections;
@@ -41,17 +41,17 @@ import static org.mockito.Mockito.*;
 @EnableConfigurationProperties({AirsonicHomeConfig.class})
 public class UserSettingsControllerTest {
 
-    @MockBean
+    @MockitoBean
     private SecurityService securityService;
-    @MockBean
+    @MockitoBean
     private SettingsService settingsService;
-    @MockBean
+    @MockitoBean
     private MediaFolderService mediaFolderService;
-    @MockBean
+    @MockitoBean
     private TranscodingService transcodingService;
-    @MockBean
+    @MockitoBean
     private PersonalSettingsService personalSettingsService;
-    @MockBean
+    @MockitoBean
     private UserService userService;
 
     @Autowired

--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaFolderServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaFolderServiceTest.java
@@ -22,8 +22,8 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.File;
@@ -52,16 +52,16 @@ public class MediaFolderServiceTest {
     @Autowired
     private MediaFolderService mediaFolderService;
 
-    @SpyBean
+    @MockitoSpyBean
     private MusicFolderRepository musicFolderRepository;
 
-    @SpyBean
+    @MockitoSpyBean
     private UserRepository userRepository;
 
-    @MockBean
+    @MockitoBean
     private CoverArtRepository coverArtRepository;
 
-    @MockBean
+    @MockitoBean
     private MediaFileRepository mediaFileRepository;
 
     @TempDir

--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTest.java
@@ -17,9 +17,9 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import java.nio.file.Path;
 import java.time.Instant;
@@ -44,16 +44,16 @@ public class MediaScannerServiceTest {
     @Autowired
     private MediaScannerService mediaScannerService;
 
-    @SpyBean
+    @MockitoSpyBean
     private MediaFileService mediaFileService;
 
-    @SpyBean
+    @MockitoSpyBean
     private SettingsService settingsService;
 
-    @SpyBean
+    @MockitoSpyBean
     private IndexManager indexManager;
 
-    @SpyBean
+    @MockitoSpyBean
     private AirsonicScanConfig scanConfig;
 
     @Autowired

--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
@@ -24,10 +24,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.data.domain.Sort;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -79,7 +79,7 @@ public class MediaScannerServiceTestCase {
     @Autowired
     private MusicFolderRepository musicFolderRepository;
 
-    @SpyBean
+    @MockitoSpyBean
     private MediaFileService mediaFileService;
 
     @Autowired
@@ -94,7 +94,7 @@ public class MediaScannerServiceTestCase {
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
-    @SpyBean
+    @MockitoSpyBean
     private SettingsService settingsService;
 
     @TempDir

--- a/airsonic-main/src/test/java/org/airsonic/player/service/SecurityServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/SecurityServiceTest.java
@@ -22,7 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import java.nio.file.Path;
 import java.util.Date;
@@ -46,10 +46,10 @@ public class SecurityServiceTest {
     @Autowired
     private SecurityService securityService;
 
-    @SpyBean
+    @MockitoSpyBean
     private UserRepository userRepository;
 
-    @SpyBean
+    @MockitoSpyBean
     private UserCredentialRepository userCredentialRepository;
 
     @TempDir

--- a/airsonic-main/src/test/java/org/airsonic/player/service/TranscodingServiceIntTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/TranscodingServiceIntTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -26,9 +26,9 @@ public class TranscodingServiceIntTest {
 
     @Autowired
     private TranscodingService transcodingService;
-    @SpyBean
+    @MockitoSpyBean
     private PlayerRepository playerRepository;
-    @SpyBean
+    @MockitoSpyBean
     private TranscodingRepository transcodingRepository;
 
     @TempDir

--- a/airsonic-main/src/test/java/org/airsonic/player/service/podcast/PodcastDownloadClientIntegrationTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/podcast/PodcastDownloadClientIntegrationTest.java
@@ -33,8 +33,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.when;
 @EnableConfigurationProperties({AirsonicHomeConfig.class})
 public class PodcastDownloadClientIntegrationTest {
 
-    @MockBean
+    @MockitoBean
     private VersionService versionService;
 
     @TempDir

--- a/airsonic-main/src/test/java/org/airsonic/player/service/podcast/PodcastDownloadClientTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/podcast/PodcastDownloadClientTest.java
@@ -54,11 +54,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -81,17 +81,17 @@ import static org.mockito.Mockito.when;
 @EnableConfigurationProperties({AirsonicHomeConfig.class})
 public class PodcastDownloadClientTest {
 
-    @MockBean
+    @MockitoBean
     private PodcastEpisodeRepository podcastEpisodeRepository;
-    @MockBean
+    @MockitoBean
     private PodcastPersistenceService podcastPersistenceService;
-    @MockBean
+    @MockitoBean
     private MediaFolderService mediaFolderService;
-    @MockBean
+    @MockitoBean
     private MediaFileService mediaFileService;
-    @MockBean
+    @MockitoBean
     private SecurityService securityService;
-    @MockBean
+    @MockitoBean
     private VersionService versionService;
     @TempDir
     private Path tempFolder;

--- a/integration-test/src/test/java/org/airsonic/test/PingIT.java
+++ b/integration-test/src/test/java/org/airsonic/test/PingIT.java
@@ -14,7 +14,7 @@ public class PingIT {
     @Test
     public void pingMissingAuthTest() {
         ResponseEntity<String> response = Scanner.rest.getForEntity(
-                UriComponentsBuilder.fromHttpUrl(Scanner.SERVER + "/rest/ping").toUriString(),
+                UriComponentsBuilder.fromUriString(Scanner.SERVER + "/rest/ping").toUriString(),
                 String.class);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());

--- a/integration-test/src/test/java/org/airsonic/test/Scanner.java
+++ b/integration-test/src/test/java/org/airsonic/test/Scanner.java
@@ -61,7 +61,7 @@ public class Scanner {
         assertFalse(isScanning());
 
         String startScan = rest.getForObject(
-                addRestParameters(UriComponentsBuilder.fromHttpUrl(SERVER + "/rest/startScan")).toUriString(),
+                addRestParameters(UriComponentsBuilder.fromUriString(SERVER + "/rest/startScan")).toUriString(),
                 String.class);
 
         System.out.println(startScan);
@@ -78,7 +78,7 @@ public class Scanner {
 
     private static boolean isScanning() {
         return rest.getForObject(
-                addRestParameters(UriComponentsBuilder.fromHttpUrl(SERVER + "/rest/getScanStatus"))
+                addRestParameters(UriComponentsBuilder.fromUriString(SERVER + "/rest/getScanStatus"))
                         .queryParam("f", "json").toUriString(),
                 SubsonicResponse.class)
             .getScanStatus().isScanning();
@@ -95,7 +95,7 @@ public class Scanner {
 
     public static List<Child> getMediaFilesInMusicFolder() {
         List<MusicFolder> musicFolder = rest.getForObject(
-                addRestParameters(UriComponentsBuilder.fromHttpUrl(SERVER + "/rest/getMusicFolders"))
+                addRestParameters(UriComponentsBuilder.fromUriString(SERVER + "/rest/getMusicFolders"))
                         .queryParam("f", "json")
                         .toUriString(),
                 SubsonicResponse.class)
@@ -108,7 +108,7 @@ public class Scanner {
 
     private static List<Child> getMediaFiles(int folderId) {
         return rest.getForObject(
-                addRestParameters(UriComponentsBuilder.fromHttpUrl(SERVER + "/rest/getIndexes"))
+                addRestParameters(UriComponentsBuilder.fromUriString(SERVER + "/rest/getIndexes"))
                         .queryParam("f", "json")
                         .queryParam("musicFolderId", folderId)
                         .toUriString(),
@@ -120,7 +120,7 @@ public class Scanner {
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(MediaType.parseMediaTypes("audio/webm,audio/ogg,audio/wav,audio/*;"));
         ResponseEntity<byte[]> response = rest.exchange(
-                addRestParameters(UriComponentsBuilder.fromHttpUrl(SERVER + "/rest/stream"))
+                addRestParameters(UriComponentsBuilder.fromUriString(SERVER + "/rest/stream"))
                         .queryParam("id", mediaFileId)
                         .toUriString(),
                 HttpMethod.GET,

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.6</version>
+        <version>3.4.3</version>
         <relativePath />
     </parent>
 
@@ -88,7 +88,7 @@
                 <artifactId>asm</artifactId>
                 <version>9.7</version>
             </dependency>
-         <dependency>
+            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.16.0</version>
@@ -117,6 +117,11 @@
                 <groupId>jakarta.xml.bind</groupId>
                 <artifactId>jakarta.xml.bind-api</artifactId>
                 <version>4.0.2</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>2.3.1</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>


### PR DESCRIPTION
This pull request includes several updates to the `airsonic-main` project, focusing on dependency version updates and replacing `MockBean` and `SpyBean` annotations with `MockitoBean` and `MockitoSpyBean` annotations in test files.

Dependency updates:

* Updated `aspectj.version` from `1.9.22.1` to `1.9.23` in `airsonic-main/pom.xml`.
* Changed the version of `cxf-spring-boot-autoconfigure` dependency to use `${cxf.version}` in `airsonic-main/pom.xml`.

Annotation replacements in test files:

* Replaced `MockBean` with `MockitoBean` and `SpyBean` with `MockitoSpyBean` in various test files:
  * `AvatarControllerTest.java`
  * `AvatarUploadControllerTest.java`
  * `CoverArtControllerTest.java`
  * `ImportPlaylistControllerTest.java`
  * `PodcastEpisodesControllerTest.java`
  * `UploadControllerTest.java`
  * `UserSettingsControllerTest.java`
  * `MediaFolderServiceTest.java`
  * `MediaScannerServiceTest.java`
  * `MediaScannerServiceTestCase.java`
  * `SecurityServiceTest.java`
  * `TranscodingServiceIntTest.java`

Other changes:

* Updated import statement for `ObjectPostProcessor` in `CustomLDAPAuthenticatorPostProcessor.java`.
* Replaced `fromHttpUrl` with `fromUriString` in `PodcastIndexService.java`.