### PR TITLE
bump org.springframework.boot to 3.3.10 which bumps tomcat 10.1.39 fixing #688 (CVE-2025-24813)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.6</version>
+        <version>3.3.10</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
By bumping org.springframework.boot to 3.3.10, org.apache.tomcat is bumped to 10.1.39. 
This fixes #688 (CVE-2025-24813)