### PR TITLE
bump springframework.boot to 3.4.4 resolving #690 (CVE-2024-31573)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.10</version>
+        <version>3.4.4</version>
         <relativePath />
     </parent>
 
@@ -247,7 +247,6 @@
                             <phase>validate</phase>
                             <configuration>
                                 <configLocation>${project.basedir}/../checkstyle.xml</configLocation>
-                                <encoding>UTF-8</encoding>
                                 <consoleOutput>true</consoleOutput>
                                 <failOnViolation>true</failOnViolation>
                                 <includeTestSourceDirectory>true</includeTestSourceDirectory>
@@ -261,7 +260,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>10.18.1</version>
+                            <version>10.23.0</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -316,7 +315,8 @@
                             <exclude>org.airsonic.player.service.search.*TestCase.java</exclude>
                         </excludes>
                         <!-- see https://github.com/mockito/mockito/issues/3037#issuecomment-1930132240-->
-                        <argLine>-javaagent:${net.bytebuddy:byte-buddy-agent:jar}</argLine> 
+                        <!--suppress UnresolvedMavenProperty -->
+                        <argLine><![CDATA[-javaagent:${net.bytebuddy:byte-buddy-agent:jar}]]></argLine>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -360,7 +360,7 @@
                 <version>3.8.1</version>
                 <executions>
                     <execution>
-                       <id>init</id> 
+                       <id>init</id>
                        <goals>
                             <goal>properties</goal>
                        </goals>


### PR DESCRIPTION
bump springframework.boot to 3.4.4, com.puppycrawl.tools 10.23.0, net.bytebuddy.byte.buddy to 1.17.5.plus minor changes. 

should resolve #690 (CVE-2024-31573)