### PR TITLE
Remove dupe and old snakeyaml version definition in airsonic-integration-test, resolves CVE-2022-1471

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -16,7 +16,6 @@
         <docker.testing.container>it-container</docker.testing.container>
         <docker.testing.host>http://localhost:4040</docker.testing.host>
         <docker.testing.default-music-folder>/tmp/music</docker.testing.default-music-folder>
-        <snakeyaml.version>2.4</snakeyaml.version>
     </properties>
 
     <dependencies>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -26,11 +26,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>${snakeyaml.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <scope>test</scope>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -16,7 +16,7 @@
         <docker.testing.container>it-container</docker.testing.container>
         <docker.testing.host>http://localhost:4040</docker.testing.host>
         <docker.testing.default-music-folder>/tmp/music</docker.testing.default-music-folder>
-        <snakeyaml.version>1.33</snakeyaml.version>
+        <snakeyaml.version>2.4</snakeyaml.version>
     </properties>
 
     <dependencies>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -26,6 +26,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snakeyaml.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Remove dupe and old snakeyaml version definition in airsonic-integration-test, resolves CVE-2022-1471.
snakeyaml was definined to version 1.33 in airsonic-integration-test.
