### PR TITLE
Update syscall filter sets in airsonic.service, resolves #712

### DIFF
--- a/contrib/airsonic.service
+++ b/contrib/airsonic.service
@@ -34,7 +34,7 @@ ProtectKernelTunables=yes
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 RestrictNamespaces=yes
 RestrictRealtime=yes
-SystemCallFilter=@basic-io @file-system @chown @network-io @sync @timer @signal @process @system-service
+SystemCallFilter=@system-service
 ReadWritePaths=/var/airsonic
 
 # You can change the following line to `strict` instead of `full`

--- a/contrib/airsonic.service
+++ b/contrib/airsonic.service
@@ -34,7 +34,9 @@ ProtectKernelTunables=yes
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 RestrictNamespaces=yes
 RestrictRealtime=yes
-SystemCallFilter=@system-service
+SystemCallFilter=@system-service @known
+# syscall restrictions. TODO: perhaps could be restricted more.
+SystemCallFilter=~@clock @cpu-emulation @debug @module @obsolete @pkey @privileged @raw-io @reboot @sandbox @swap
 ReadWritePaths=/var/airsonic
 
 # You can change the following line to `strict` instead of `full`


### PR DESCRIPTION
Updates to syscall filter sets in airsonic.service:
* Remove duplicate sets already covered by @system-service
* Add set @known
* Add restrictions to multiple sets

Resolves #712 

When releasing, please notify users to update their airsonic service!