### PR TITLE
#741  Fixed edge CI deployment

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -66,10 +66,13 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           mkdir -p airsonic-main/target/classes
+          mkdir -p airsonic-main/target/generated/build-metadata
       - uses: actions/download-artifact@v4
         with:
           name: build-metadata
           path: airsonic-main/target/classes/  
+      - run: |
+          cp airsonic-main/target/classes/build.properties airsonic-main/target/generated/build-metadata/build.properties
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
This pull request makes a small enhancement to the `.github/workflows/edge.yml` workflow file. It adds steps to create a new directory for build metadata and copy the `build.properties` file into it, ensuring proper organization of generated build artifacts.

Key changes:

* [`.github/workflows/edge.yml`](diffhunk://#diff-a8e31e174e3ddce38cb2351c978bb5d63bd46c41235a13c9dc12763e26afef05R69-R75): Added a command to create the `airsonic-main/target/generated/build-metadata` directory and a step to copy the `build.properties` file into this directory.