### PR TITLE
[update] #750 Added Artist API tests and refactored

### DIFF
--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -208,7 +208,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.27.1</version>
+            <version>1.28.0</version>
         </dependency>
         <dependency>
 <!--            compression library-->

--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -694,7 +694,7 @@
                 <!-- Change to non-snapshot version once it is released (change groupId) -->
                 <groupId>dev.aspectj</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
-                <version>1.14</version>
+                <version>1.14.1</version>
                 <dependencies>
                   <dependency>
                     <groupId>org.aspectj</groupId>

--- a/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JaxbContentService.java
@@ -1,0 +1,211 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2025 (C) Y.Tory
+ */
+package org.airsonic.player.service;
+
+import org.airsonic.player.controller.CoverArtController;
+import org.airsonic.player.controller.JAXBWriter;
+import org.airsonic.player.domain.Album;
+import org.airsonic.player.domain.CoverArt;
+import org.airsonic.player.domain.MediaFile;
+import org.airsonic.player.domain.Player;
+import org.airsonic.player.domain.Playlist;
+import org.airsonic.player.util.StringUtil;
+import org.springframework.stereotype.Service;
+import org.subsonic.restapi.AlbumID3;
+import org.subsonic.restapi.ArtistID3;
+import org.subsonic.restapi.Child;
+
+import java.time.Instant;
+import java.util.Objects;
+
+@Service
+public class JaxbContentService {
+
+    private final JAXBWriter jaxbWriter = new JAXBWriter();
+    private final ArtistService artistService;
+    private final CoverArtService coverArtService;
+    private final PlaylistService playlistService;
+    private final AlbumService albumService;
+    private final MediaFileService mediaFileService;
+    private final TranscodingService transcodingService;
+    private final RatingService ratingService;
+
+    JaxbContentService(
+            ArtistService artistService,
+            CoverArtService coverArtService,
+            PlaylistService playlistService,
+            AlbumService albumService,
+            MediaFileService mediaFileService,
+            TranscodingService transcodingService,
+            RatingService ratingService) {
+        this.artistService = artistService;
+        this.coverArtService = coverArtService;
+        this.playlistService = playlistService;
+        this.albumService = albumService;
+        this.mediaFileService = mediaFileService;
+        this.transcodingService = transcodingService;
+        this.ratingService = ratingService;
+    }
+
+    public <T extends ArtistID3> T createJaxbArtist(T jaxbArtist, org.airsonic.player.domain.Artist artist, String username) {
+        jaxbArtist.setId(String.valueOf(artist.getId()));
+        jaxbArtist.setName(artist.getName());
+        jaxbArtist.setStarred(jaxbWriter.convertDate(artistService.getStarredDate(artist.getId(), username)));
+        jaxbArtist.setAlbumCount(artist.getAlbumCount());
+        if (!CoverArt.NULL_ART.equals(coverArtService.getArtistArt(artist.getId()))) {
+            jaxbArtist.setCoverArt(CoverArtController.ARTIST_COVERART_PREFIX + artist.getId());
+        }
+        return jaxbArtist;
+    }
+
+    public org.subsonic.restapi.Artist createJaxbArtist(MediaFile artist, String username) {
+        org.subsonic.restapi.Artist result = new org.subsonic.restapi.Artist();
+        result.setId(String.valueOf(artist.getId()));
+        result.setName(artist.getTitle() != null ? artist.getTitle() : artist.getArtist());
+        Instant starred = mediaFileService.getMediaFileStarredDate(artist, username);
+        result.setStarred(jaxbWriter.convertDate(starred));
+        // TODO: add rating. https://opensubsonic.netlify.app/docs/responses/artist/
+        return result;
+    }
+
+    public <T extends AlbumID3> T createJaxbAlbum(T jaxbAlbum, Album album, String username) {
+        jaxbAlbum.setId(String.valueOf(album.getId()));
+        jaxbAlbum.setName(album.getName());
+        if (album.getArtist() != null) {
+            jaxbAlbum.setArtist(album.getArtist());
+            org.airsonic.player.domain.Artist artist = artistService.getArtist(album.getArtist());
+            if (artist != null) {
+                jaxbAlbum.setArtistId(String.valueOf(artist.getId()));
+            }
+        }
+        if (!CoverArt.NULL_ART.equals(coverArtService.getAlbumArt(album.getId()))) {
+            jaxbAlbum.setCoverArt(CoverArtController.ALBUM_COVERART_PREFIX + album.getId());
+        }
+        jaxbAlbum.setSongCount(album.getSongCount());
+        jaxbAlbum.setDuration((int) Math.round(album.getDuration()));
+        jaxbAlbum.setCreated(jaxbWriter.convertDate(album.getCreated()));
+        jaxbAlbum.setStarred(jaxbWriter.convertDate(albumService.getAlbumStarredDate(album.getId(), username)));
+        jaxbAlbum.setYear(album.getYear());
+        jaxbAlbum.setGenre(album.getGenre());
+        return jaxbAlbum;
+    }
+
+    public <T extends org.subsonic.restapi.Playlist> T createJaxbPlaylist(T jaxbPlaylist, Playlist playlist) {
+        jaxbPlaylist.setId(String.valueOf(playlist.getId()));
+        jaxbPlaylist.setName(playlist.getName());
+        jaxbPlaylist.setComment(playlist.getComment());
+        jaxbPlaylist.setOwner(playlist.getUsername());
+        jaxbPlaylist.setPublic(playlist.getShared());
+        jaxbPlaylist.setSongCount(playlist.getFileCount());
+        jaxbPlaylist.setDuration((int) Math.round(playlist.getDuration()));
+        jaxbPlaylist.setCreated(jaxbWriter.convertDate(playlist.getCreated()));
+        jaxbPlaylist.setChanged(jaxbWriter.convertDate(playlist.getChanged()));
+        jaxbPlaylist.setCoverArt(CoverArtController.PLAYLIST_COVERART_PREFIX + playlist.getId());
+
+        for (String username : playlistService.getPlaylistUsers(playlist.getId())) {
+            jaxbPlaylist.getAllowedUser().add(username);
+        }
+        return jaxbPlaylist;
+    }
+
+    public Child createJaxbChild(Player player, MediaFile mediaFile, String username) {
+        return createJaxbChild(new Child(), player, mediaFile, username);
+    }
+
+    public <T extends Child> T createJaxbChild(T child, Player player, MediaFile mediaFile, String username) {
+        MediaFile parent = mediaFileService.getParentOf(mediaFile);
+        child.setId(String.valueOf(mediaFile.getId()));
+        try {
+            if (Objects.nonNull(parent) && !mediaFileService.isRoot(parent)) {
+                child.setParent(String.valueOf(parent.getId()));
+            }
+        } catch (SecurityException x) {
+            // Ignored.
+        }
+        child.setTitle(mediaFile.getName());
+        child.setAlbum(mediaFile.getAlbumName());
+        child.setArtist(mediaFile.getArtist());
+        child.setIsDir(mediaFile.isDirectory());
+        child.setCoverArt(findCoverArt(mediaFile, parent));
+        child.setYear(mediaFile.getYear());
+        child.setGenre(mediaFile.getGenre());
+        child.setCreated(jaxbWriter.convertDate(mediaFile.getCreated()));
+        child.setStarred(jaxbWriter.convertDate(mediaFileService.getMediaFileStarredDate(mediaFile, username)));
+        child.setUserRating(ratingService.getRatingForUser(username, mediaFile));
+        child.setAverageRating(ratingService.getAverageRating(mediaFile));
+        child.setPlayCount((long) mediaFile.getPlayCount());
+
+        if (mediaFile.isFile()) {
+            Double mediaFileDuration = mediaFile.getDuration();
+            child.setDuration((int) Math.round(mediaFileDuration == null ? 0 : mediaFileDuration));
+            child.setBitRate(mediaFile.getBitRate());
+            child.setTrack(mediaFile.getTrackNumber());
+            child.setDiscNumber(mediaFile.getDiscNumber());
+            child.setSize(mediaFile.getFileSize());
+            String suffix = mediaFile.getFormat();
+            child.setSuffix(suffix);
+            child.setContentType(StringUtil.getMimeType(suffix));
+            child.setIsVideo(mediaFile.isVideo());
+            child.setPath(mediaFile.getPath());
+
+            Album album = albumService.getAlbumByMediaFile(mediaFile);
+
+            if (album != null) {
+                child.setAlbumId(String.valueOf(album.getId()));
+            }
+            org.airsonic.player.domain.Artist artist = artistService.getArtist(mediaFile.getArtist());
+            if (artist != null) {
+                child.setArtistId(String.valueOf(artist.getId()));
+            }
+            switch (mediaFile.getMediaType()) {
+                case MUSIC:
+                    child.setType(org.subsonic.restapi.MediaType.MUSIC);
+                    break;
+                case PODCAST:
+                    child.setType(org.subsonic.restapi.MediaType.PODCAST);
+                    break;
+                case AUDIOBOOK:
+                    child.setType(org.subsonic.restapi.MediaType.AUDIOBOOK);
+                    break;
+                case VIDEO:
+                    child.setType(org.subsonic.restapi.MediaType.VIDEO);
+                    child.setOriginalWidth(mediaFile.getWidth());
+                    child.setOriginalHeight(mediaFile.getHeight());
+                    break;
+                default:
+                    break;
+            }
+
+            if (transcodingService.isTranscodingRequired(mediaFile, player)) {
+                String transcodedSuffix = transcodingService.getSuffix(player, mediaFile, null);
+                child.setTranscodedSuffix(transcodedSuffix);
+                child.setTranscodedContentType(StringUtil.getMimeType(transcodedSuffix));
+            }
+        }
+        return child;
+    }
+
+    private String findCoverArt(MediaFile mediaFile, MediaFile parent) {
+        MediaFile dir = mediaFile.isDirectory() ? mediaFile : parent;
+        if (dir != null && !CoverArt.NULL_ART.equals(coverArtService.getMediaFileArt(dir.getId()))) {
+            return String.valueOf(dir.getId());
+        }
+        return null;
+    }
+}

--- a/airsonic-main/src/main/java/org/airsonic/player/service/LibraryStatusService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/LibraryStatusService.java
@@ -1,0 +1,110 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2025 (C) Y.Tory
+ Copyright 2016 (C) Airsonic Authors
+ Based upon Subsonic, Copyright 2009 (C) Sindre Mehus
+ */
+package org.airsonic.player.service;
+
+import org.airsonic.player.domain.*;
+import org.airsonic.player.util.FileUtil;
+import org.springframework.stereotype.Service;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+
+@Service
+public class LibraryStatusService {
+
+    // Update this time if you want to force a refresh in clients.
+    private static final Instant LAST_COMPATIBILITY_TIME = Instant.parse("2012-03-06T00:00:00.00Z");
+
+    private final MediaScannerService mediaScannerService;
+    private final SettingsService settingsService;
+    private final PersonalSettingsService personalSettingsService;
+    private final MediaFolderService mediaFolderService;
+    private final InternetRadioService internetRadioService;
+
+    LibraryStatusService(
+        MediaScannerService mediaScannerService,
+        SettingsService settingsService,
+        PersonalSettingsService personalSettingsService,
+        MediaFolderService mediaFolderService,
+        InternetRadioService internetRadioService
+    ) {
+        this.mediaScannerService = mediaScannerService;
+        this.settingsService = settingsService;
+        this.personalSettingsService = personalSettingsService;
+        this.mediaFolderService = mediaFolderService;
+        this.internetRadioService = internetRadioService;
+    }
+
+    /**
+     * Note: This class intentionally does not implement org.springframework.web.servlet.mvc.LastModified
+     * as we don't need browser-side caching of left.html.  This method is only used by RESTController.
+     */
+    public long getLastModified(String username, Integer musicFolderId) throws Exception {
+        if (musicFolderId != null) {
+            // Note: UserSettings.setChanged() is intentionally not called. This would break browser caching
+            // of the left frame.
+            personalSettingsService.updateSelectedMusicFolderId(username, musicFolderId);
+        }
+
+        if (mediaScannerService.isScanning()) {
+            return -1L;
+        }
+
+        long lastModified = LAST_COMPATIBILITY_TIME.toEpochMilli();
+        UserSettings userSettings = personalSettingsService.getUserSettings(username);
+
+        // When was settings last changed?
+        lastModified = Math.max(lastModified, settingsService.getSettingsChanged());
+
+        // When was music folder(s) on disk last changed?
+
+        List<MusicFolder> allMusicFolders = mediaFolderService.getMusicFoldersForUser(username);
+        MusicFolder selectedMusicFolder = allMusicFolders.stream()
+                .filter(f -> f.getId().equals(userSettings.getSelectedMusicFolderId()))
+                .findAny().orElse(null);
+        if (selectedMusicFolder != null) {
+            Path file = selectedMusicFolder.getPath();
+            lastModified = Math.max(lastModified, FileUtil.lastModified(file).toEpochMilli());
+        } else {
+            for (MusicFolder musicFolder : allMusicFolders) {
+                Path file = musicFolder.getPath();
+                lastModified = Math.max(lastModified, FileUtil.lastModified(file).toEpochMilli());
+            }
+        }
+
+        // When was music folder table last changed?
+        for (MusicFolder musicFolder : allMusicFolders) {
+            lastModified = Math.max(lastModified, musicFolder.getChanged().toEpochMilli());
+        }
+
+        // When was internet radio table last changed?
+        for (InternetRadio internetRadio : internetRadioService.getEnabledInternetRadios()) {
+            lastModified = Math.max(lastModified, internetRadio.getChanged().toEpochMilli());
+        }
+
+        // When was user settings last changed?
+        lastModified = Math.max(lastModified, userSettings.getChanged().toEpochMilli());
+
+        return lastModified;
+    }
+
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/api/AbstractRESTTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/api/AbstractRESTTest.java
@@ -1,0 +1,70 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2025 (C) Y.Tory
+ */
+package org.airsonic.player.api;
+
+import org.airsonic.player.TestCaseUtils;
+import org.airsonic.player.domain.MusicFolder;
+import org.airsonic.player.service.LibraryStatusService;
+import org.airsonic.player.service.MediaFolderService;
+import org.airsonic.player.service.PlayerService;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public abstract class AbstractRESTTest {
+
+    protected static final String AIRSONIC_USER = "admin";
+    protected static final String AIRSONIC_PASSWORD = "admin";
+    protected static final String EXPECTED_FORMAT = "json";
+
+    protected static String AIRSONIC_API_VERSION = TestCaseUtils.restApiVersion();
+
+    protected MusicFolder testFolder = new MusicFolder(1, Paths.get("/test/folder"), "Test Folder", MusicFolder.Type.MEDIA, true, Instant.now());
+
+    @Autowired
+    protected MockMvc mvc;
+
+    @Autowired
+    protected PlayerService playerService;
+
+    @MockitoBean
+    protected MediaFolderService mediaFolderService;
+
+    @MockitoBean
+    protected LibraryStatusService libraryStatusService;
+
+    @TempDir
+    private static Path tempAirsonicHome;
+
+    @BeforeAll
+    public static void beforeAll() {
+        System.setProperty("airsonic.home", tempAirsonicHome.toString());
+    }
+
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/api/AirsonicRestApiIntTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/api/AirsonicRestApiIntTest.java
@@ -18,44 +18,17 @@
  */
 package org.airsonic.player.api;
 
-import org.airsonic.player.TestCaseUtils;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.nio.file.Path;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-public class AirsonicRestApiIntTest {
+public class AirsonicRestApiIntTest extends AbstractRESTTest {
 
     private static final String CLIENT_NAME = "airsonic";
-    private static final String AIRSONIC_USER = "admin";
-    private static final String AIRSONIC_PASSWORD = "admin";
-    private static final String EXPECTED_FORMAT = "json";
-
-    private static String AIRSONIC_API_VERSION = TestCaseUtils.restApiVersion();
-
-    @Autowired
-    private MockMvc mvc;
-
-    @TempDir
-    private static Path tempAirsonicHome;
-
-    @BeforeAll
-    public static void beforeAll() {
-        System.setProperty("airsonic.home", tempAirsonicHome.toString());
-    }
 
     @Test
     public void pingTest() throws Exception {

--- a/airsonic-main/src/test/java/org/airsonic/player/api/ArtistAPITest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/api/ArtistAPITest.java
@@ -30,10 +30,14 @@ import org.airsonic.player.domain.Player;
 import org.airsonic.player.service.AlbumService;
 import org.airsonic.player.service.ArtistService;
 import org.airsonic.player.service.CoverArtService;
+import org.airsonic.player.service.JaxbContentService;
 import org.airsonic.player.service.LastFmService;
+import org.airsonic.player.service.LibraryStatusService;
 import org.airsonic.player.service.MediaFileService;
 import org.airsonic.player.service.MediaFolderService;
+import org.airsonic.player.service.MusicIndexService;
 import org.airsonic.player.service.PlayerService;
+import org.airsonic.player.service.RatingService;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -91,8 +95,20 @@ public class ArtistAPITest {
     @MockitoBean
     private LastFmService lastFmService;
 
+    @MockitoBean
+    private LibraryStatusService libraryStatusService;
+
+    @MockitoSpyBean
+    private MusicIndexService musicIndexService;
+
+    @MockitoBean
+    private RatingService ratingService;
+
     @MockitoSpyBean
     private MediaFileService mediaFileService;
+
+    @MockitoSpyBean
+    private JaxbContentService jaxbContentService;
 
     @Autowired
     private PlayerService playerService;
@@ -583,5 +599,4 @@ public class ArtistAPITest {
         assertFalse(artistInfo2.contains("musicBrainzId"));
         assertFalse(artistInfo2.contains("lastFmUrl"));
     }
-
 }

--- a/airsonic-main/src/test/java/org/airsonic/player/api/CORSTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/api/CORSTest.java
@@ -1,43 +1,35 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2025 (C) Y.Tory
+ */
 package org.airsonic.player.api;
 
-import org.airsonic.player.TestCaseUtils;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.nio.file.Path;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 
-@AutoConfigureMockMvc
-@SpringBootTest
-public class CORSTest {
+public class CORSTest extends AbstractRESTTest {
 
     private static final String CLIENT_NAME = "airsonic";
-    private static final String AIRSONIC_USER = "admin";
-    private static final String AIRSONIC_PASSWORD = "admin";
-    private static final String EXPECTED_FORMAT = "json";
-    private static String AIRSONIC_API_VERSION = TestCaseUtils.restApiVersion();
-
-    @Autowired
-    private MockMvc mvc;
-
-    @TempDir
-    private static Path tempAirsonicHome;
-
-    @BeforeAll
-    public static void beforeAll() {
-        System.setProperty("airsonic.home", tempAirsonicHome.toString());
-    }
 
     @Test
     public void corsHeadersShouldBeAddedToSuccessResponses() throws Exception {

--- a/airsonic-main/src/test/java/org/airsonic/player/api/LicenseApiTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/api/LicenseApiTest.java
@@ -1,0 +1,76 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2025 (C) Y.Tory
+ */
+package org.airsonic.player.api;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import org.airsonic.player.domain.Player;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.MediaType;
+
+import jakarta.transaction.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+public class LicenseApiTest extends AbstractRESTTest {
+
+    private static final String CLIENT_NAME = "licenseApiTest";
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/rest/getLicense", "/rest/getLicense.view"})
+    void getLicense_returnsValidLicense(String endpoint) throws Exception {
+        String response = mvc.perform(get(endpoint)
+            .param("v", AIRSONIC_API_VERSION)
+            .param("c", CLIENT_NAME)
+            .param("u", AIRSONIC_USER)
+            .param("p", AIRSONIC_PASSWORD)
+            .param("f", EXPECTED_FORMAT)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.subsonic-response.status").value("ok"))
+            .andExpect(jsonPath("$.subsonic-response.version").value(AIRSONIC_API_VERSION))
+            .andDo(print())
+            .andReturn().getResponse().getContentAsString();
+
+        DocumentContext json = JsonPath.parse(response);
+        String licenseEmail = json.read("$.subsonic-response.license.email");
+        boolean licenseValid = json.read("$.subsonic-response.license.valid");
+
+        // assertions
+        assertEquals("airsonic@github.com",licenseEmail);
+        assertTrue(licenseValid);
+        assertTrue(response.contains("licenseExpires"));
+        assertTrue(response.contains("trialExpires"));
+
+        // Check if the players list is not empty
+        List<Player> players = playerService.getPlayersForUserAndClientId(AIRSONIC_USER, CLIENT_NAME);
+        assertEquals(1, players.size());
+        Player player = players.get(0);
+        WrapRequestUtil.assertRestAPIPlayer(player, CLIENT_NAME, AIRSONIC_USER);
+    }
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/api/MusicFolderAPITest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/api/MusicFolderAPITest.java
@@ -1,0 +1,97 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2025 (C) Y.Tory
+ Copyright 2016 (C) Airsonic Authors
+ Based upon Subsonic, Copyright 2009 (C) Sindre Mehus
+ */
+package org.airsonic.player.api;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import org.airsonic.player.domain.Player;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import jakarta.transaction.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+public class MusicFolderAPITest extends AbstractRESTTest {
+
+    private static final String CLIENT_NAME = "musicFolderApiTest";
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/rest/getMusicFolders", "/rest/getMusicFolders.view"})
+    public void getMusicFolders_returnsFolders(String endpoint) throws Exception {
+        when(mediaFolderService.getMusicFoldersForUser(eq(AIRSONIC_USER))).thenReturn(List.of(testFolder));
+        String response = mvc.perform(get(endpoint)
+                .param("v", AIRSONIC_API_VERSION)
+                .param("c", CLIENT_NAME)
+                .param("u", AIRSONIC_USER)
+                .param("p", AIRSONIC_PASSWORD)
+                .param("f", EXPECTED_FORMAT))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.status").value("ok"))
+                .andExpect(jsonPath("$.subsonic-response.version").value(AIRSONIC_API_VERSION))
+                .andDo(print())
+                .andReturn().getResponse().getContentAsString();
+
+        DocumentContext json = JsonPath.parse(response);
+        List<String> folderNames = json.read("$.subsonic-response.musicFolders.musicFolder[*].name");
+        List<Integer> folderIds = json.read("$.subsonic-response.musicFolders.musicFolder[*].id");
+        assertEquals(1, folderIds.size());
+        assertEquals(1, folderNames.size());
+        assertEquals(testFolder.getName(), folderNames.get(0));
+        assertEquals(testFolder.getId(), folderIds.get(0));
+
+        List<Player> players = playerService.getPlayersForUserAndClientId(AIRSONIC_USER, CLIENT_NAME);
+        assertEquals(1, players.size());
+        Player player = players.get(0);
+        WrapRequestUtil.assertRestAPIPlayer(player, CLIENT_NAME, AIRSONIC_USER);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/rest/getMusicFolders", "/rest/getMusicFolders.view"})
+    public void getMusicFolders_emptyList(String endpoint) throws Exception {
+        when(mediaFolderService.getMusicFoldersForUser(eq(AIRSONIC_USER))).thenReturn(Collections.emptyList());
+        mvc.perform(get(endpoint)
+                .param("v", AIRSONIC_API_VERSION)
+                .param("c", CLIENT_NAME)
+                .param("u", AIRSONIC_USER)
+                .param("p", AIRSONIC_PASSWORD)
+                .param("f", EXPECTED_FORMAT))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.status").value("ok"))
+                .andExpect(jsonPath("$.subsonic-response.musicFolders").isEmpty())
+                .andDo(print());
+
+        List<Player> players = playerService.getPlayersForUserAndClientId(AIRSONIC_USER, CLIENT_NAME);
+        assertEquals(1, players.size());
+        Player player = players.get(0);
+        WrapRequestUtil.assertRestAPIPlayer(player, CLIENT_NAME, AIRSONIC_USER);
+    }
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
@@ -1,0 +1,357 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2025 (C) Y.Tory
+ */
+package org.airsonic.player.service;
+
+import org.airsonic.player.controller.CoverArtController;
+import org.airsonic.player.domain.Album;
+import org.airsonic.player.domain.Artist;
+import org.airsonic.player.domain.CoverArt;
+import org.airsonic.player.domain.MediaFile;
+import org.airsonic.player.domain.Player;
+import org.airsonic.player.domain.Playlist;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.subsonic.restapi.AlbumID3;
+import org.subsonic.restapi.ArtistID3;
+import org.subsonic.restapi.Child;
+import org.subsonic.restapi.MediaType;
+
+import java.time.Instant;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JaxbContentServiceTest {
+    @Mock
+    private ArtistService artistService;
+    @Mock
+    private CoverArtService coverArtService;
+    @Mock
+    private PlaylistService playlistService;
+    @Mock
+    private AlbumService albumService;
+    @Mock
+    private MediaFileService mediaFileService;
+    @Mock
+    private TranscodingService transcodingService;
+    @Mock
+    private RatingService ratingService;
+
+    @InjectMocks
+    private JaxbContentService service;
+
+    @Nested
+    public class JaxbArtistTest {
+        @Mock
+        private Artist artist;
+        private CoverArt coverArt = new CoverArt();
+
+        @Test
+        void createJaxbArtist_setsFieldsCorrectly() {
+            Instant starredDate = Instant.now();
+            ArtistID3 jaxbArtist = new ArtistID3();
+            when(artist.getId()).thenReturn(42);
+            when(artist.getName()).thenReturn("Test Artist");
+            when(artist.getAlbumCount()).thenReturn(3);
+            when(artistService.getStarredDate(eq(42), anyString())).thenReturn(starredDate);
+            when(coverArtService.getArtistArt(42)).thenReturn(coverArt);
+
+            ArtistID3 result = service.createJaxbArtist(jaxbArtist, artist, "user");
+
+            assertEquals("42", result.getId());
+            assertEquals("Test Artist", result.getName());
+            assertEquals(3, result.getAlbumCount());
+            assertThat(result.getStarred()).isNotNull();
+            assertEquals(CoverArtController.ARTIST_COVERART_PREFIX + "42", result.getCoverArt());
+        }
+
+        @Test
+        void createJaxbArtist_noCoverArt() {
+            ArtistID3 jaxbArtist = new ArtistID3();
+            Artist artist = mock(Artist.class);
+            when(artist.getId()).thenReturn(1);
+            when(artist.getName()).thenReturn("NoArt");
+            when(artist.getAlbumCount()).thenReturn(0);
+            when(artistService.getStarredDate(eq(1), anyString())).thenReturn(null);
+            when(coverArtService.getArtistArt(1)).thenReturn(CoverArt.NULL_ART);
+
+            ArtistID3 result = service.createJaxbArtist(jaxbArtist, artist, "user");
+            assertNull(result.getCoverArt());
+            assertNull(result.getStarred());
+            assertEquals("1", result.getId());
+            assertEquals("NoArt", result.getName());
+            assertEquals(0, result.getAlbumCount());
+        }
+    }
+
+    @Nested
+    public class JaxbAlbumTest {
+        @Mock
+        private Album album;
+        @Mock
+        private Artist artist;
+        private CoverArt coverArt = new CoverArt();
+        private Instant starredDate = Instant.now();
+
+        @Test
+        void createJaxbAlbum_setsFieldsCorrectly() {
+            AlbumID3 jaxbAlbum = new AlbumID3();
+            when(album.getId()).thenReturn(10);
+            when(album.getName()).thenReturn("AlbumName");
+            when(album.getArtist()).thenReturn("ArtistName");
+            when(album.getSongCount()).thenReturn(12);
+            when(album.getDuration()).thenReturn(1234.5);
+            when(album.getCreated()).thenReturn(starredDate);
+            when(album.getYear()).thenReturn(2020);
+            when(album.getGenre()).thenReturn("Rock");
+            when(coverArtService.getAlbumArt(10)).thenReturn(coverArt);
+            when(albumService.getAlbumStarredDate(10, "user")).thenReturn(starredDate);
+            when(coverArtService.getAlbumArt(10)).thenReturn(coverArt);
+            when(artistService.getArtist("ArtistName")).thenReturn(artist);
+            when(artist.getId()).thenReturn(99);
+
+            AlbumID3 result = service.createJaxbAlbum(jaxbAlbum, album, "user");
+
+            assertEquals("10", result.getId());
+            assertEquals("AlbumName", result.getName());
+            assertEquals("ArtistName", result.getArtist());
+            assertEquals("99", result.getArtistId());
+            assertEquals(CoverArtController.ALBUM_COVERART_PREFIX + "10", result.getCoverArt());
+            assertEquals(12, result.getSongCount());
+            assertEquals(1235, result.getDuration());
+            assertNotNull(result.getCreated());
+            assertNotNull(result.getStarred());
+            assertEquals(2020, result.getYear());
+            assertEquals("Rock", result.getGenre());
+        }
+
+        @Test
+        void createJaxbAlbum_noArtistOrCoverArt() {
+            AlbumID3 jaxbAlbum = new AlbumID3();
+            when(album.getId()).thenReturn(2);
+            when(album.getName()).thenReturn("NoArtist");
+            when(album.getArtist()).thenReturn(null);
+            when(album.getSongCount()).thenReturn(0);
+            when(album.getDuration()).thenReturn(0.0);
+            when(album.getCreated()).thenReturn(null);
+            when(album.getYear()).thenReturn(null);
+            when(album.getGenre()).thenReturn(null);
+            when(coverArtService.getAlbumArt(2)).thenReturn(CoverArt.NULL_ART);
+            when(albumService.getAlbumStarredDate(2, "user")).thenReturn(null);
+
+            AlbumID3 result = service.createJaxbAlbum(jaxbAlbum, album, "user");
+
+            assertNull(result.getArtistId());
+            assertNull(result.getCoverArt());
+        }
+    }
+
+    @Nested
+    public class JaxbPlaylistTest {
+        @Mock
+        private Playlist playlist;
+
+        @Test
+        void createJaxbPlaylist_setsFieldsCorrectly() {
+            org.subsonic.restapi.Playlist jaxbPlaylist = new org.subsonic.restapi.Playlist();
+            Playlist playlist = mock(Playlist.class);
+            when(playlist.getId()).thenReturn(5);
+            when(playlist.getName()).thenReturn("MyPlaylist");
+            when(playlist.getComment()).thenReturn("A comment");
+            when(playlist.getUsername()).thenReturn("owner");
+            when(playlist.getShared()).thenReturn(true);
+            when(playlist.getFileCount()).thenReturn(7);
+            when(playlist.getDuration()).thenReturn(321.0);
+            when(playlist.getCreated()).thenReturn(Instant.ofEpochMilli(33333333L));
+            when(playlist.getChanged()).thenReturn(Instant.ofEpochMilli(44444444L));
+            when(playlistService.getPlaylistUsers(5)).thenReturn(Arrays.asList("user1", "user2"));
+
+            org.subsonic.restapi.Playlist result = service.createJaxbPlaylist(jaxbPlaylist, playlist);
+
+            assertEquals("5", result.getId());
+            assertEquals("MyPlaylist", result.getName());
+            assertEquals("A comment", result.getComment());
+            assertEquals("owner", result.getOwner());
+            assertEquals(true, result.isPublic());
+            assertEquals(7, result.getSongCount());
+            assertEquals(321, result.getDuration());
+            assertNotNull(result.getCreated());
+            assertNotNull(result.getChanged());
+            assertEquals(CoverArtController.PLAYLIST_COVERART_PREFIX + "5", result.getCoverArt());
+            assertEquals(Arrays.asList("user1", "user2"), result.getAllowedUser());
+        }
+    }
+
+    @Nested
+    class JaxbChildTest {
+        @Mock
+        private MediaFile mediaFile;
+        @Mock
+        private MediaFile parent;
+        private CoverArt coverArt = new CoverArt();
+
+        @Test
+        void createJaxbChild_setsFieldsForFile() {
+            Player player = mock(Player.class);
+            when(mediaFileService.getParentOf(mediaFile)).thenReturn(parent);
+            when(mediaFile.getId()).thenReturn(100);
+            when(parent.getId()).thenReturn(99);
+            when(mediaFileService.isRoot(parent)).thenReturn(false);
+            when(mediaFile.getName()).thenReturn("song.mp3");
+            when(mediaFile.getAlbumName()).thenReturn("Album");
+            when(mediaFile.getArtist()).thenReturn("Artist");
+            when(mediaFile.isDirectory()).thenReturn(false);
+            when(mediaFile.isFile()).thenReturn(true);
+            when(mediaFile.getYear()).thenReturn(2021);
+            when(mediaFile.getGenre()).thenReturn("Pop");
+            when(mediaFile.getCreated()).thenReturn(Instant.ofEpochMilli(55555555L));
+            when(mediaFileService.getMediaFileStarredDate(mediaFile, "user"))
+                    .thenReturn(Instant.ofEpochMilli(66666666L));
+            when(ratingService.getRatingForUser("user", mediaFile)).thenReturn(4);
+            when(ratingService.getAverageRating(mediaFile)).thenReturn(3.5);
+            when(mediaFile.getPlayCount()).thenReturn(10);
+            when(mediaFile.getDuration()).thenReturn(200.0);
+            when(mediaFile.getBitRate()).thenReturn(320);
+            when(mediaFile.getTrackNumber()).thenReturn(1);
+            when(mediaFile.getDiscNumber()).thenReturn(1);
+            when(mediaFile.getFileSize()).thenReturn(123456L);
+            when(mediaFile.getFormat()).thenReturn("mp3");
+            when(mediaFile.isVideo()).thenReturn(false);
+            when(mediaFile.getPath()).thenReturn("/music/song.mp3");
+            when(mediaFile.getMediaType()).thenReturn(MediaFile.MediaType.MUSIC);
+            Album album = mock(Album.class);
+            when(albumService.getAlbumByMediaFile(mediaFile)).thenReturn(album);
+            when(album.getId()).thenReturn(77);
+            Artist artist = mock(Artist.class);
+            when(artistService.getArtist("Artist")).thenReturn(artist);
+            when(artist.getId()).thenReturn(88);
+            when(coverArtService.getMediaFileArt(99)).thenReturn(coverArt);
+            when(transcodingService.isTranscodingRequired(mediaFile, player)).thenReturn(true);
+            when(transcodingService.getSuffix(player, mediaFile, null)).thenReturn("ogg");
+
+            Child child = service.createJaxbChild(player, mediaFile, "user");
+            assertEquals("100", child.getId());
+            assertEquals("99", child.getParent());
+            assertEquals("song.mp3", child.getTitle());
+            assertEquals("Album", child.getAlbum());
+            assertEquals("Artist", child.getArtist());
+            assertFalse(child.isIsDir());
+            assertEquals("99", child.getCoverArt());
+            assertEquals(2021, child.getYear());
+            assertEquals("Pop", child.getGenre());
+            assertNotNull(child.getCreated());
+            assertNotNull(child.getStarred());
+            assertEquals(4, child.getUserRating());
+            assertEquals(3.5, child.getAverageRating());
+            assertEquals(10L, child.getPlayCount());
+            assertEquals(200, child.getDuration());
+            assertEquals(320, child.getBitRate());
+            assertEquals(1, child.getTrack());
+            assertEquals(1, child.getDiscNumber());
+            assertEquals(123456L, child.getSize());
+            assertEquals("mp3", child.getSuffix());
+            assertNotNull(child.getContentType());
+            assertFalse(child.isIsVideo());
+            assertEquals("/music/song.mp3", child.getPath());
+            assertEquals("77", child.getAlbumId());
+            assertEquals("88", child.getArtistId());
+            assertEquals(MediaType.MUSIC, child.getType());
+            assertEquals("ogg", child.getTranscodedSuffix());
+            assertNotNull(child.getTranscodedContentType());
+        }
+
+        @Test
+        void createJaxbChild_setsFieldsForDirectory() {
+            Player player = mock(Player.class);
+            MediaFile mediaFile = mock(MediaFile.class);
+            when(mediaFileService.getParentOf(mediaFile)).thenReturn(null);
+            when(mediaFile.getId()).thenReturn(200);
+            when(mediaFile.isDirectory()).thenReturn(true);
+            when(mediaFile.isFile()).thenReturn(false);
+            when(coverArtService.getMediaFileArt(200)).thenReturn(coverArt);
+
+            Child child = service.createJaxbChild(player, mediaFile, "user");
+
+            assertEquals("200", child.getId());
+            assertTrue(child.isIsDir());
+            assertEquals("200", child.getCoverArt());
+        }
+
+        @Test
+        void createJaxbChild_noCoverArt() {
+            Player player = mock(Player.class);
+            MediaFile mediaFile = mock(MediaFile.class);
+            when(mediaFileService.getParentOf(mediaFile)).thenReturn(null);
+            when(mediaFile.getId()).thenReturn(300);
+            when(mediaFile.isDirectory()).thenReturn(true);
+            when(mediaFile.isFile()).thenReturn(false);
+            when(coverArtService.getMediaFileArt(300)).thenReturn(CoverArt.NULL_ART);
+
+            Child child = service.createJaxbChild(player, mediaFile, "user");
+
+            assertNull(child.getCoverArt());
+        }
+    }
+
+    @Nested
+    class CreateJaxbArtistFromMediaFileTest {
+        @Test
+        void createJaxbArtist_fromMediaFile_setsFieldsCorrectly_withTitle() {
+            MediaFile mediaFile = mock(MediaFile.class);
+            when(mediaFile.getId()).thenReturn(123);
+            when(mediaFile.getTitle()).thenReturn("Artist Title");
+            when(mediaFile.getArtist()).thenReturn("Artist Name");
+            when(mediaFileService.getMediaFileStarredDate(mediaFile, "user"))
+                    .thenReturn(Instant.ofEpochMilli(123456789L));
+
+            org.subsonic.restapi.Artist result = service.createJaxbArtist(mediaFile, "user");
+
+            assertEquals("123", result.getId());
+            assertEquals("Artist Title", result.getName());
+            assertNotNull(result.getStarred());
+        }
+
+        @Test
+        void createJaxbArtist_fromMediaFile_setsFieldsCorrectly_withNullTitle() {
+            MediaFile mediaFile = mock(MediaFile.class);
+            when(mediaFile.getId()).thenReturn(124);
+            when(mediaFile.getTitle()).thenReturn(null);
+            when(mediaFile.getArtist()).thenReturn("Artist Name");
+            when(mediaFileService.getMediaFileStarredDate(mediaFile, "user")).thenReturn(null);
+
+            org.subsonic.restapi.Artist result = service.createJaxbArtist(mediaFile, "user");
+
+            assertEquals("124", result.getId());
+            assertEquals("Artist Name", result.getName());
+            assertNull(result.getStarred());
+        }
+    }
+
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/JaxbContentServiceTest.java
@@ -327,7 +327,6 @@ class JaxbContentServiceTest {
             MediaFile mediaFile = mock(MediaFile.class);
             when(mediaFile.getId()).thenReturn(123);
             when(mediaFile.getTitle()).thenReturn("Artist Title");
-            when(mediaFile.getArtist()).thenReturn("Artist Name");
             when(mediaFileService.getMediaFileStarredDate(mediaFile, "user"))
                     .thenReturn(Instant.ofEpochMilli(123456789L));
 

--- a/airsonic-main/src/test/java/org/airsonic/player/service/LibraryStatusServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/LibraryStatusServiceTest.java
@@ -1,0 +1,128 @@
+package org.airsonic.player.service;
+
+import org.airsonic.player.domain.*;
+import org.airsonic.player.util.FileUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class LibraryStatusServiceTest {
+
+    @Mock
+    private MediaScannerService mediaScannerService;
+    @Mock
+    private SettingsService settingsService;
+    @Mock
+    private PersonalSettingsService personalSettingsService;
+    @Mock
+    private MediaFolderService mediaFolderService;
+    @Mock
+    private InternetRadioService internetRadioService;
+    @InjectMocks
+    private LibraryStatusService libraryStatusService;
+
+    @Mock
+    private UserSettings userSettings;
+
+    @Test
+    void getLastModified_returnsMinusOne_whenMediaScannerIsScanning() throws Exception {
+        when(mediaScannerService.isScanning()).thenReturn(true);
+
+        long result = libraryStatusService.getLastModified("user", null);
+
+        assertEquals(-1L, result);
+        verify(mediaScannerService).isScanning();
+        verifyNoMoreInteractions(mediaScannerService, settingsService, personalSettingsService, mediaFolderService, internetRadioService);
+    }
+
+    @Test
+    void getLastModified_updatesSelectedMusicFolderId_whenMusicFolderIdIsNotNull() throws Exception {
+        when(mediaScannerService.isScanning()).thenReturn(false);
+        when(personalSettingsService.getUserSettings("user")).thenReturn(userSettings);
+        when(userSettings.getChanged()).thenReturn(Instant.now().plusSeconds(1000));
+        when(settingsService.getSettingsChanged()).thenReturn(0L);
+        when(mediaFolderService.getMusicFoldersForUser("user")).thenReturn(Collections.emptyList());
+        when(internetRadioService.getEnabledInternetRadios()).thenReturn(Collections.emptyList());
+
+        libraryStatusService.getLastModified("user", 42);
+
+        verify(personalSettingsService).updateSelectedMusicFolderId("user", 42);
+    }
+
+    @Test
+    void getLastModified_returnsMaxOfAllRelevantTimestamps() throws Exception {
+        String username = "user";
+        Integer musicFolderId = null;
+
+        Instant now = Instant.now();
+
+        when(personalSettingsService.getUserSettings(username)).thenReturn(userSettings);
+        when(userSettings.getSelectedMusicFolderId()).thenReturn(1);
+        when(userSettings.getChanged()).thenReturn(now.plusSeconds(1000));
+
+        when(settingsService.getSettingsChanged()).thenReturn(now.plusSeconds(2000).toEpochMilli());
+
+        MusicFolder folder1 = mock(MusicFolder.class);
+        when(folder1.getId()).thenReturn(1);
+        Path folder1Path = mock(Path.class);
+        when(folder1.getPath()).thenReturn(folder1Path);
+        when(folder1.getChanged()).thenReturn(now.plusSeconds(3000));
+
+        MusicFolder folder2 = mock(MusicFolder.class);
+        Path folder2Path = mock(Path.class);
+        when(folder2.getChanged()).thenReturn(now.plusSeconds(3500));
+
+        List<MusicFolder> folders = Arrays.asList(folder1, folder2);
+        when(mediaFolderService.getMusicFoldersForUser(username)).thenReturn(folders);
+
+        InternetRadio radio1 = mock(InternetRadio.class);
+        when(radio1.getChanged()).thenReturn(now.plusSeconds(5000));
+        InternetRadio radio2 = mock(InternetRadio.class);
+        when(radio2.getChanged()).thenReturn(now.plusSeconds(2500));
+        when(internetRadioService.getEnabledInternetRadios()).thenReturn(Arrays.asList(radio1, radio2));
+
+        try (MockedStatic<FileUtil> fileUtilMock = mockStatic(FileUtil.class)) {
+            fileUtilMock.when(() -> FileUtil.lastModified(folder1Path)).thenReturn(now.plusSeconds(6000));
+            fileUtilMock.when(() -> FileUtil.lastModified(folder2Path)).thenReturn(now.plusSeconds(4000));
+
+            long result = libraryStatusService.getLastModified(username, musicFolderId);
+
+            assertEquals(now.plusSeconds(6000L).toEpochMilli(), result);
+        }
+    }
+
+    @Test
+    void getLastModified_handlesNoMusicFoldersOrRadios() throws Exception {
+        String username = "user";
+        when(mediaScannerService.isScanning()).thenReturn(false);
+
+        when(personalSettingsService.getUserSettings(username)).thenReturn(userSettings);
+        when(userSettings.getChanged()).thenReturn(Instant.ofEpochMilli(1000L));
+        when(settingsService.getSettingsChanged()).thenReturn(500L);
+        when(mediaFolderService.getMusicFoldersForUser(username)).thenReturn(Collections.emptyList());
+        when(internetRadioService.getEnabledInternetRadios()).thenReturn(Collections.emptyList());
+
+        long expected = Math.max(
+                Instant.parse("2012-03-06T00:00:00.00Z").toEpochMilli(),
+                Math.max(500L, 1000L)
+        );
+
+        long result = libraryStatusService.getLastModified(username, null);
+
+        assertEquals(expected, result);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
-                <version>9.7</version>
+                <version>9.8</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
-                    <version>0.45.1</version>
+                    <version>0.46.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This pull request introduces significant refactoring and cleanup in the `LeftController` and `SubsonicRESTController` classes, with the primary goal of improving maintainability and modularity. Key changes include the removal of unused code and dependencies, as well as the delegation of JAXB-related operations to a new `JaxbContentService`. Additionally, a new `LibraryStatusService` replaces the `getLastModified` method in `LeftController` for handling library status checks.

### Refactoring and Cleanup:
- **`LeftController`**: 
  - Removed the `LAST_COMPATIBILITY_TIME` constant and the `getLastModified` method, along with associated logic for determining the last modified timestamp of various entities. This functionality has been moved to `LibraryStatusService`. [[1]](diffhunk://#diff-f654c6c8b2c37a26abf0b4fd4ee75d8127c0e98e379b291bb05c013597334f75L51-L52) [[2]](diffhunk://#diff-f654c6c8b2c37a26abf0b4fd4ee75d8127c0e98e379b291bb05c013597334f75L74-L123)
  - Eliminated unused imports and comments to streamline the code. [[1]](diffhunk://#diff-f654c6c8b2c37a26abf0b4fd4ee75d8127c0e98e379b291bb05c013597334f75L25) [[2]](diffhunk://#diff-f654c6c8b2c37a26abf0b4fd4ee75d8127c0e98e379b291bb05c013597334f75L38-L39)

- **`SubsonicRESTController`**:
  - Removed unused `@Autowired` dependencies, such as `LeftController`, `CoverArtService`, and `TranscodingService`. [[1]](diffhunk://#diff-095ef95f08d7e643d1067d4f18b5fef8766ccc86788d9800b2e71ac83c449322L104-L105) [[2]](diffhunk://#diff-095ef95f08d7e643d1067d4f18b5fef8766ccc86788d9800b2e71ac83c449322L114-L115) [[3]](diffhunk://#diff-095ef95f08d7e643d1067d4f18b5fef8766ccc86788d9800b2e71ac83c449322L154-R161)
  - Replaced custom JAXB creation methods (e.g., `createJaxbArtist`, `createJaxbAlbum`, `createJaxbChild`) with calls to `JaxbContentService` for better modularity and reuse. [[1]](diffhunk://#diff-095ef95f08d7e643d1067d4f18b5fef8766ccc86788d9800b2e71ac83c449322L250-R249) [[2]](diffhunk://#diff-095ef95f08d7e643d1067d4f18b5fef8766ccc86788d9800b2e71ac83c449322L283-R282) [[3]](diffhunk://#diff-095ef95f08d7e643d1067d4f18b5fef8766ccc86788d9800b2e71ac83c449322L542-L590) [[4]](diffhunk://#diff-095ef95f08d7e643d1067d4f18b5fef8766ccc86788d9800b2e71ac83c449322L605-R549)
  - Updated the `getIndexes` method to use `LibraryStatusService` for determining the last modified timestamp, instead of relying on `LeftController`.

### Dependency Injection Enhancements:
- Added new `@Autowired` dependencies for `LibraryStatusService` and `JaxbContentService` in `SubsonicRESTController`. These services centralize functionality that was previously scattered across the codebase.

### Functional Changes:
- Updated methods like `getIndexes`, `getSongsByGenre`, `getArtists`, and others to utilize `JaxbContentService` for creating JAXB objects, ensuring consistency in data transformation logic. [[1]](diffhunk://#diff-095ef95f08d7e643d1067d4f18b5fef8766ccc86788d9800b2e71ac83c449322L239) [[2]](diffhunk://#diff-095ef95f08d7e643d1067d4f18b5fef8766ccc86788d9800b2e71ac83c449322L323-R322) [[3]](diffhunk://#diff-095ef95f08d7e643d1067d4f18b5fef8766ccc86788d9800b2e71ac83c449322L452-R451)

This refactoring simplifies the codebase, reduces duplication, and enhances maintainability by adhering to the single responsibility principle.