### PR TITLE
fix: #772 Fix url handling with context-path

### DIFF
--- a/airsonic-main/src/main/resources/templates/right.html
+++ b/airsonic-main/src/main/resources/templates/right.html
@@ -6,6 +6,9 @@
     <script type="text/javascript" th:src="@{/script/utils.js}"></script>
 
     <script type="text/javascript" th:inline="javascript">
+        // Pass the evaluated Thymeleaf URL to JS variable
+        const nowPlayingStatusUrl = /*[[@{/nowPlaying/status}]]*/ "/nowPlaying/status";
+
         class TaskQueue {
           constructor() {
             this.q = [];
@@ -103,10 +106,13 @@
 
         async function addStatus(status, table) {
             const tableRoot = document.getElementById(table + 'Table');
+            if (!tableRoot) {
+                return;
+            }
             const selector = '.playstatus-' + status.transferId;
 
-
-            const res = await fetch(`/nowPlaying/status?id=${encodeURIComponent(status.transferId)}`, { credentials: 'same-origin' });
+            const statusUrl = nowPlayingStatusUrl + "?id=" + status.transferId;
+            const res = await fetch(statusUrl, { credentials: 'same-origin' });
 
             if (!res.ok) {
                 return;


### PR DESCRIPTION
Fix #772 
This pull request introduces improvements to how the `nowPlaying/status` URL is handled in the `right.html` template. 
The previous version cannot handle the nowPlaying/status, if you configure CONTEXT_PATH. 

**URL Handling Improvements**
* Added a JavaScript variable `nowPlayingStatusUrl` that uses Thymeleaf to evaluate the correct URL for `nowPlaying/status`, replacing hardcoded strings and improving maintainability.
* Updated the `addStatus` function to use the new `nowPlayingStatusUrl` variable when constructing the fetch request, ensuring consistency and correctness.

**Robustness**
* Added a check in `addStatus` to return early if the target table element does not exist, preventing potential JavaScript errors.