### PR TITLE
#662 Fixed the logic of getting files from playlist

### DIFF
--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.32.0
+        uses: aquasecurity/trivy-action@0.33.0
         with:
           scan-type: 'fs'
           format: 'sarif'

--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jmx</artifactId>
-            <version>4.2.33</version>
+            <version>4.2.34</version>
         </dependency>
         <!-- END Metrics -->
 

--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jmx</artifactId>
-            <version>4.2.33</version>
+            <version>4.2.35</version>
         </dependency>
         <!-- END Metrics -->
 

--- a/airsonic-main/src/main/java/org/airsonic/player/repository/PlaylistMediaFileRepository.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/repository/PlaylistMediaFileRepository.java
@@ -1,9 +1,40 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2025 (C) Y.Tory
+ */
 package org.airsonic.player.repository;
 
+import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.domain.PlaylistMediaFile;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface PlaylistMediaFileRepository extends JpaRepository<PlaylistMediaFile, Integer> {
+
+    @Query("""
+        select pmf.mediaFile
+        from PlaylistMediaFile pmf
+        where pmf.playlist.id = :playlistId
+        order by pmf.orderIndex
+        """)
+    List<MediaFile> findMediaFilesByPlaylistId(@Param("playlistId") Integer playlistId);
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/StreamService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/StreamService.java
@@ -1,0 +1,8 @@
+package org.airsonic.player.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class StreamService {
+
+}

--- a/airsonic-main/src/test/java/org/airsonic/player/repository/PlaylistMediaFileRepositoryTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/repository/PlaylistMediaFileRepositoryTest.java
@@ -1,0 +1,172 @@
+/*
+ This file is part of Airsonic.
+
+ Airsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Airsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2025 (C) Y.Tory
+ */
+package org.airsonic.player.repository;
+
+import org.airsonic.player.domain.MediaFile;
+import org.airsonic.player.domain.MediaFile.MediaType;
+import org.airsonic.player.domain.MusicFolder;
+import org.airsonic.player.domain.MusicFolder.Type;
+import org.airsonic.player.domain.Playlist;
+import org.airsonic.player.domain.PlaylistMediaFile;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import jakarta.transaction.Transactional;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Transactional
+@SpringBootTest
+class PlaylistMediaFileRepositoryTest {
+
+    @Autowired
+    private PlaylistMediaFileRepository playlistMediaFileRepository;
+
+    @Autowired
+    private PlaylistRepository playlistRepository;
+    @Autowired
+    private MusicFolderRepository musicFolderRepository;
+
+    @Autowired
+    private MediaFileRepository mediaFileRepository;
+
+    @TempDir
+    private static Path tempDir;
+
+    @BeforeAll
+    public static void setUp() {
+        System.setProperty("airsonic.home", tempDir.toString());
+    }
+
+    @TempDir
+    private Path tempMusicDir;
+
+    @Test
+    public void testGetMediaFilesByRelativePathAndFolderId() {
+        // prepare folder
+        MusicFolder testFolder = new MusicFolder(tempMusicDir, "name", Type.MEDIA, true,
+                Instant.now().truncatedTo(ChronoUnit.MICROS));
+        musicFolderRepository.save(testFolder);
+        // prepare MediaFile
+        MediaFile baseFile = new MediaFile();
+        baseFile.setFolder(testFolder);
+        baseFile.setPath("test.wav");
+        baseFile.setMediaType(MediaType.MUSIC);
+        baseFile.setIndexPath("test.cue");
+        baseFile.setStartPosition(MediaFile.NOT_INDEXED);
+        baseFile.setCreated(Instant.now());
+        baseFile.setChanged(Instant.now());
+        baseFile.setLastScanned(Instant.now());
+        baseFile.setChildrenLastUpdated(Instant.now());
+        mediaFileRepository.save(baseFile);
+        // prepare playlist
+        Playlist playlist = new Playlist(
+                "admin", false, "Test Playlist", "A test playlist", 1,
+                300.0, Instant.now(), Instant.now(), "importedFromTest");
+        playlistRepository.save(playlist);
+
+        // relation
+        PlaylistMediaFile pmf = new PlaylistMediaFile();
+        pmf.setPlaylist(playlist);
+        pmf.setMediaFile(baseFile);
+        pmf.setOrderIndex(1);
+        playlistMediaFileRepository.save(pmf);
+
+        // execute
+        List<MediaFile> result = playlistMediaFileRepository.findMediaFilesByPlaylistId(playlist.getId());
+
+        assertEquals(1, result.size());
+        assertEquals(baseFile, result.get(0));
+
+    }
+
+    @Test
+    @DisplayName("findMediaFilesByPlaylistId returns media files in order for given playlist")
+    void testFindMediaFilesByPlaylistId() {
+
+        Playlist playlist = new Playlist(
+                "admin", false, "Test Playlist", "A test playlist", 1,
+                300.0, Instant.now(), Instant.now(), "importedFromTest");
+        playlist = playlistRepository.save(playlist);
+
+        // prepare folder
+        MusicFolder testFolder = new MusicFolder(tempMusicDir, "name", Type.MEDIA, true,
+                Instant.now().truncatedTo(ChronoUnit.MICROS));
+        musicFolderRepository.save(testFolder);
+        // prepare MediaFile
+        MediaFile baseFile = new MediaFile();
+        baseFile.setFolder(testFolder);
+        baseFile.setPath("test.wav");
+        baseFile.setMediaType(MediaType.MUSIC);
+        baseFile.setIndexPath("test.cue");
+        baseFile.setStartPosition(MediaFile.NOT_INDEXED);
+        baseFile.setCreated(Instant.now());
+        baseFile.setChanged(Instant.now());
+        baseFile.setLastScanned(Instant.now());
+        baseFile.setChildrenLastUpdated(Instant.now());
+        mediaFileRepository.save(baseFile);
+
+        MediaFile baseFile2 = new MediaFile();
+        baseFile2.setFolder(testFolder);
+        baseFile2.setPath("test2.wav");
+        baseFile2.setMediaType(MediaType.MUSIC);
+        baseFile2.setIndexPath("test2.cue");
+        baseFile2.setStartPosition(MediaFile.NOT_INDEXED);
+        baseFile2.setCreated(Instant.now());
+        baseFile2.setChanged(Instant.now());
+        baseFile2.setLastScanned(Instant.now());
+        baseFile2.setChildrenLastUpdated(Instant.now());
+        mediaFileRepository.save(baseFile2);
+
+        PlaylistMediaFile pmf1 = new PlaylistMediaFile();
+        pmf1.setPlaylist(playlist);
+        pmf1.setMediaFile(baseFile);
+        pmf1.setOrderIndex(2);
+
+        PlaylistMediaFile pmf2 = new PlaylistMediaFile();
+        pmf2.setPlaylist(playlist);
+        pmf2.setMediaFile(baseFile2);
+        pmf2.setOrderIndex(1);
+
+        playlistMediaFileRepository.save(pmf1);
+        playlistMediaFileRepository.save(pmf2);
+
+        List<MediaFile> result = playlistMediaFileRepository.findMediaFilesByPlaylistId(playlist.getId());
+
+        assertEquals(2, result.size());
+        assertEquals(baseFile2, result.get(0));
+        assertEquals(baseFile, result.get(1));
+    }
+
+    @Test
+    @DisplayName("findMediaFilesByPlaylistId returns empty list for non-existent playlist")
+    void testFindMediaFilesByPlaylistIdEmpty() {
+        List<MediaFile> result = playlistMediaFileRepository.findMediaFilesByPlaylistId(-1);
+        assertEquals(0, result.size());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
-                <version>1.21.1</version>
+                <version>1.21.2</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.activation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-core</artifactId>
-                <version>4.2.33</version>
+                <version>4.2.34</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.persistence</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-core</artifactId>
-                <version>4.2.33</version>
+                <version>4.2.35</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.persistence</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
             <dependency>
                 <groupId>org.checkerframework</groupId>
                 <artifactId>checker-qual</artifactId>
-                <version>3.49.5</version>
+                <version>3.50.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.j2objc</groupId>


### PR DESCRIPTION
Fix #662
This pull request refactors playlist creation and retrieval logic, improves separation of concerns, and introduces new repository methods and tests for handling playlist media files. 
The main changes include moving playlist-related logic out of the controller into the service layer, updating dependency injection patterns, and adding a dedicated repository and test coverage for playlist media file retrieval.

**Playlist creation and controller/service refactoring:**

* Refactored `PlaylistWSController` to remove direct dependencies on `MediaFolderService` and `PlayerService`, delegating playlist creation for starred songs and play queues to new service methods (`createPlaylistForStarredSongs`, `createPlaylistForPlayQueue`) in `PlaylistService`. This simplifies the controller and centralizes playlist logic. [[1]](diffhunk://#diff-5df98d322d68f65518e39195005c35a6f624b12e86f4dfc6eafc0bb1d5fb325fL41-L44) [[2]](diffhunk://#diff-5df98d322d68f65518e39195005c35a6f624b12e86f4dfc6eafc0bb1d5fb325fL58-L117)
* Updated `PlaylistService` to use constructor-based dependency injection for all required services and repositories, improving testability and code clarity.

**Repository and data access improvements:**

* Added `PlaylistMediaFileRepository` with a new `findMediaFilesByPlaylistId` method to efficiently fetch media files for a playlist, ordered by their position. The service layer now uses this repository instead of traversing entity relationships directly. [[1]](diffhunk://#diff-b6a51dd51187702e7d17e30117a90100dfaf93c6226f50555ae5fec02b502e97R1-R39) [[2]](diffhunk://#diff-ccc0c78018553190f0df3756a7156e3e7c0ab20fe39c4d3567c04df0df15ba43R170-L163)

**Service layer enhancements:**

* Implemented new transactional methods in `PlaylistService` for creating playlists from play queues and starred songs, encapsulating formatting, resource bundle lookup, and file assignment logic.

**Test coverage:**

* Added `PlaylistMediaFileRepositoryTest` to verify correct retrieval and ordering of media files for playlists, including edge cases for empty results.
* Updated `PlaylistServiceTest` to mock the new repository and ensure compatibility with the refactored service. [[1]](diffhunk://#diff-2597b761b983db41a6f91d0e973d2c7622409bf920ef7ec2453c529fad90add9R42-R44) [[2]](diffhunk://#diff-2597b761b983db41a6f91d0e973d2c7622409bf920ef7ec2453c529fad90add9L75-R78)

[[1]](diffhunk://#diff-5df98d322d68f65518e39195005c35a6f624b12e86f4dfc6eafc0bb1d5fb325fL41-L44) [[2]](diffhunk://#diff-5df98d322d68f65518e39195005c35a6f624b12e86f4dfc6eafc0bb1d5fb325fL58-L117) [[3]](diffhunk://#diff-ccc0c78018553190f0df3756a7156e3e7c0ab20fe39c4d3567c04df0df15ba43L58-R90) [[4]](diffhunk://#diff-b6a51dd51187702e7d17e30117a90100dfaf93c6226f50555ae5fec02b502e97R1-R39) [[5]](diffhunk://#diff-ccc0c78018553190f0df3756a7156e3e7c0ab20fe39c4d3567c04df0df15ba43R170-L163) [[6]](diffhunk://#diff-ccc0c78018553190f0df3756a7156e3e7c0ab20fe39c4d3567c04df0df15ba43R451-R492) [[7]](diffhunk://#diff-2e318ca34680c6dde378c6c48afc1bba973b872c1470501116ce5b3d1404350dR1-R172) [[8]](diffhunk://#diff-2597b761b983db41a6f91d0e973d2c7622409bf920ef7ec2453c529fad90add9R42-R44) [[9]](diffhunk://#diff-2597b761b983db41a6f91d0e973d2c7622409bf920ef7ec2453c529fad90add9L75-R78)