### PR TITLE
add AIRSONIC_MEMORY environment varialbe

### DIFF
--- a/install/docker/Dockerfile
+++ b/install/docker/Dockerfile
@@ -19,7 +19,7 @@ FROM eclipse-temurin:${IMAGE_JAVA_VERSION}-jre-jammy
 LABEL description="Airsonic-Advanced is a free, web-based media streamer, providing ubiquitous access to your music." \
       url="https://github.com/kagemomiji/airsonic-advanced"
 
-ENV AIRSONIC_PORT=4040 AIRSONIC_DIR=/var CONTEXT_PATH=/ UPNP_PORT=4041 PUID=0 PGID=0
+ENV AIRSONIC_PORT=4040 AIRSONIC_DIR=/var CONTEXT_PATH=/ UPNP_PORT=4041 PUID=0 PGID=0 AIRSONIC_MEMORY=256m
 
 WORKDIR $AIRSONIC_DIR
 

--- a/install/docker/run.sh
+++ b/install/docker/run.sh
@@ -20,7 +20,7 @@ if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
     while IFS= read -r -d '' item; do
         java_opts_array+=( "$item" )
     done < <([[ $JAVA_OPTS ]] && xargs printf '%s\0' <<<"$JAVA_OPTS")
-    exec java -Xmx256m \
+    exec java -Xmx${AIRSONIC_MEMORY:-256m} \
      -cp /app/WEB-INF/classes:/app/WEB-INF/lib/*:/app/WEB-INF/lib-provided/* \
      -Dserver.address=0.0.0.0 \
      -Dserver.port=$AIRSONIC_PORT \


### PR DESCRIPTION
This allows to specify the -Xmx paramter to control how much memory the java process is allowed to use. If not specified the default "256m" will be used.