### PR TITLE
fix: kagemomiji#663 complete Sonos migration from JSP to Thymeleaf

### DIFF
--- a/airsonic-main/src/main/resources/templates/sonosLinkLogin.html
+++ b/airsonic-main/src/main/resources/templates/sonosLinkLogin.html
@@ -17,17 +17,15 @@
 
             <img th:src="${themes?.get('logoImage') ?: 'icons/default_light/logo.png'}" alt=""/>
 
-            <div class="loginmessagetop" th:text="${model.loginMessage}"></div>
-
-            <input type="hidden" value="${model.linkCode}" name="linkCode"/>
+            <input type="hidden" th:value="${model.linkCode}" name="linkCode"/>
 
             <input required type="text" autofocus id="j_username" name="j_username" tabindex="1" th:placeholder="#{login.username}"/>
 
             <input required type="password" autocomplete="off"  name="j_password" tabindex="2" th:placeholder="#{login.password}" />
 
-            <input name="submit" type="submit" th:value="#{login.login}/>" tabindex="4"></td>
+            <input name="submit" type="submit" th:value="#{login.login}" tabindex="4"/>
 
-            <th:block th:unless="${#strings.empty(model.error)}">
+            <th:block th:if="${model['error']}">
                 <div class="loginmessagebottom">
                     <span class="warning" th:text="#{login.error}"></span>
                 </div>


### PR DESCRIPTION
Close #663 and address the Sonos link regression introduced in #375.

Description of changes:

1. The sonos java class doesn't use a loginMessage, so that can be removed. 
2. An (unreported) error for missing linkcode is due to the incomplete transition to Thymeleaf in line 22 (new line 20)
3. Syntax error in line 28 (new line 26)
4. The Error checking was flawed because on the initial GET request, the controller doesn't set the error property at all (it only sets it on POST when login fails). We need to check if it exists first before trying to access it, or in this case, use the safe navigation operator. This uses bracket notation which returns null if the key doesn't exist, rather than throwing an exception in line 30 (new line 28)
