### PR TITLE
Fix multifile CUE indexed track materialisation

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -51,6 +51,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.digitalmediaserver.cuelib.CueParser;
 import org.digitalmediaserver.cuelib.CueSheet;
+import org.digitalmediaserver.cuelib.FileData;
 import org.digitalmediaserver.cuelib.Position;
 import org.digitalmediaserver.cuelib.TrackData;
 import org.digitalmediaserver.cuelib.io.FLACReader;
@@ -821,28 +822,38 @@ public class MediaFileService {
 
         // cue tracks
         if (isEnableCueIndexing) {
-            List<MediaFile> indexedTracks = cueSheets.entrySet().parallelStream().flatMap(e -> {
+            List<MediaFile> indexedTracks = cueSheets.entrySet().stream().flatMap(e -> {
                 String indexPath = e.getKey();
                 CueSheet cueSheet = e.getValue();
 
-                String filePath = cueSheet.getFileData().get(0).getFile();
-                MediaFile base = bareFiles.remove(FilenameUtils.getName(filePath));
-
-                if (Objects.nonNull(base)) {
-                    base.setIndexPath(indexPath); // update indexPath in mediaFile
-                    Instant mediaChanged = FileUtil.lastModified(base.getFullPath());
-                    Instant cueChanged = FileUtil.lastModified(base.getFullIndexPath());
-                    base.setChanged(mediaChanged.compareTo(cueChanged) >= 0 ? mediaChanged : cueChanged);
-                    updateMediaFile(base);
-                    List<MediaFile> tracks = createIndexedTracks(base, cueSheet);
-                    // remove stored children that are now indexed
-                    tracks.forEach(t -> storedChildrenMap.remove(Pair.of(t.getPath(), t.getStartPosition())));
-                    tracks.add(base);
-                    return tracks.stream();
-                } else {
-                    LOG.warn("Could not find base file '{}' for cue sheet {}", filePath, indexPath);
-                    return Stream.empty();
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Processing cuesheet {} with {} file block(s) and {} track(s)", indexPath,
+                            cueSheet.getFileData().size(), cueSheet.getAllTrackData().size());
+                    cueSheet.getFileData().forEach(fileData -> LOG.debug("Cuesheet {} FILE '{}' type '{}' has {} track(s)",
+                            indexPath, fileData.getFile(), fileData.getFileType(), fileData.getTrackData().size()));
                 }
+
+                return cueSheet.getFileData().stream().flatMap(fileData -> {
+                    String filePath = fileData.getFile();
+                    MediaFile base = bareFiles.remove(FilenameUtils.getName(filePath));
+
+                    if (Objects.nonNull(base)) {
+                        LOG.debug("Resolved cuesheet {} FILE '{}' to base media file '{}'", indexPath, filePath, base.getPath());
+                        base.setIndexPath(indexPath); // update indexPath in mediaFile
+                        Instant mediaChanged = FileUtil.lastModified(base.getFullPath());
+                        Instant cueChanged = FileUtil.lastModified(base.getFullIndexPath());
+                        base.setChanged(mediaChanged.compareTo(cueChanged) >= 0 ? mediaChanged : cueChanged);
+                        updateMediaFile(base);
+                        List<MediaFile> tracks = createIndexedTracks(base, cueSheet, fileData);
+                        // remove stored children that are now indexed
+                        tracks.forEach(t -> storedChildrenMap.remove(Pair.of(t.getPath(), t.getStartPosition())));
+                        tracks.add(base);
+                        return tracks.stream();
+                    } else {
+                        LOG.warn("Could not find base file '{}' for cue sheet {}", filePath, indexPath);
+                        return Stream.empty();
+                    }
+                });
             }).collect(Collectors.toList());
             result.addAll(indexedTracks);
         }
@@ -1176,6 +1187,11 @@ public class MediaFileService {
 
     @Nonnull
     private List<MediaFile> createIndexedTracks(@Nonnull MediaFile base, @Nullable CueSheet cueSheet) {
+        return createIndexedTracks(base, cueSheet, getFileDataForBase(base, cueSheet));
+    }
+
+    @Nonnull
+    private List<MediaFile> createIndexedTracks(@Nonnull MediaFile base, @Nullable CueSheet cueSheet, @Nullable FileData fileData) {
 
         Map<Pair<String, Double>, MediaFile> storedChildrenMap = mediaFileRepository.findByFolderAndPath(base.getFolder(), base.getPath()).parallelStream()
             .filter(MediaFile::isIndexedTrack).collect(Collectors.toConcurrentMap(i -> Pair.of(i.getPath(), i.getStartPosition()), i -> i));
@@ -1183,7 +1199,7 @@ public class MediaFileService {
         List<MediaFile> children = new ArrayList<>();
 
         try {
-            if (Objects.isNull(cueSheet)) {
+            if (Objects.isNull(cueSheet) || Objects.isNull(fileData)) {
                 base.setIndexPath(null);
                 updateMediaFile(base);
                 return children;
@@ -1202,12 +1218,12 @@ public class MediaFileService {
             Instant childrenLastUpdated = Instant.now().plusSeconds(100 * 365 * 24 * 60 * 60); // now + 100 years, tracks do not have children
             MusicFolder baseFolder = base.getFolder();
 
-            boolean update = needsUpdate(base, settingsService.isFastCacheEnabled());
-            int trackSize = cueSheet.getAllTrackData().size();
+            List<TrackData> cueTracks = fileData.getTrackData();
+            int trackSize = cueTracks.size();
 
             if (trackSize > 0) {
-                TrackData lastTrackData = cueSheet.getAllTrackData().get(trackSize - 1);
-                double lastTrackStart = lastTrackData.getIndices().get(0).getPosition().getMinutes() * 60 + lastTrackData.getIndices().get(0).getPosition().getSeconds() + (lastTrackData.getIndices().get(0).getPosition().getFrames() / 75);
+                TrackData lastTrackData = cueTracks.get(trackSize - 1);
+                double lastTrackStart = getStartPosition(lastTrackData);
                 if (lastTrackStart >= wholeFileLength) {
                     base.setIndexPath(null);
                     updateMediaFile(base);
@@ -1216,67 +1232,58 @@ public class MediaFileService {
             }
 
             for (int i = 0; i < trackSize; i++) {
-                TrackData trackData = cueSheet.getAllTrackData().get(i);
-                Position currentPosition = trackData.getIndices().get(0).getPosition();
-                // convert CUE timestamp (minutes:seconds:frames, 75 frames/second) to fractional seconds
-                double currentStart = currentPosition.getMinutes() * 60 + currentPosition.getSeconds() + (currentPosition.getFrames() / 75);
+                TrackData trackData = cueTracks.get(i);
+                double currentStart = getStartPosition(trackData);
                 double nextStart = 0.0;
-                if (cueSheet.getAllTrackData().size() - 1 != i) {
-                    Position nextPosition = cueSheet.getAllTrackData().get(i + 1).getIndices().get(0).getPosition();
-                    nextStart = nextPosition.getMinutes() * 60 + nextPosition.getSeconds() + (nextPosition.getFrames() / 75);
+                if (cueTracks.size() - 1 != i) {
+                    nextStart = getStartPosition(cueTracks.get(i + 1));
                 } else {
                     nextStart = wholeFileLength;
                 }
 
                 double duration = nextStart - currentStart;
+                LOG.debug("Creating indexed cue track {} from FILE '{}' on base '{}' start {} duration {}",
+                        trackData.getNumber(), trackData.getParent().getFile(), basePath, currentStart, duration);
 
                 MediaFile existingFile = storedChildrenMap.remove(Pair.of(basePath, currentStart));
-                // check whether track has same duration, cue file may have been edited to split tracks
-                if ((existingFile != null) && (existingFile.getDuration() != duration)) {
-                    storedChildrenMap.put(Pair.of(basePath, currentStart), existingFile);
-                    existingFile = null;
+                MediaFile track = (existingFile != null) ? existingFile : new MediaFile();
+                track.setPath(basePath);
+                track.setAlbumArtist(performer);
+                track.setAlbumName(albumName);
+                track.setTitle(trackData.getTitle());
+                track.setArtist(trackData.getPerformer());
+                track.setParentPath(parentPath);
+                track.setFolder(baseFolder);
+                track.setChanged(lastModified);
+                track.setLastScanned(Instant.now());
+                track.setChildrenLastUpdated(childrenLastUpdated);
+                track.setCreated(lastModified);
+                track.setPresent(true);
+                track.setTrackNumber(trackData.getNumber());
+                track.setDiscNumber(base.getDiscNumber());
+                track.setGenre(base.getGenre());
+                track.setYear(base.getYear());
+                track.setBitRate(base.getBitRate());
+                track.setVariableBitRate(base.isVariableBitRate());
+                track.setHeight(base.getHeight());
+                track.setWidth(base.getWidth());
+                track.setFormat(base.getFormat());
+                track.setStartPosition(currentStart);
+                track.setDuration(duration);
+                // estimate file size based on duration and whole file size
+                long estimatedSize = (long) (duration / wholeFileLength * wholeFileSize);
+                // if estimated size is within of whole file size, use it. Otherwise use whole file size divided by number of tracks
+                if (estimatedSize > 0 && estimatedSize <= wholeFileSize) {
+                    track.setFileSize(estimatedSize);
+                } else {
+                    track.setFileSize((long)(wholeFileSize / trackSize));
                 }
-                MediaFile track = existingFile;
-                if (update || (existingFile == null)) {
-                    track = (existingFile != null) ? existingFile : new MediaFile();
-                    track.setPath(basePath);
-                    track.setAlbumArtist(performer);
-                    track.setAlbumName(albumName);
-                    track.setTitle(trackData.getTitle());
-                    track.setArtist(trackData.getPerformer());
-                    track.setParentPath(parentPath);
-                    track.setFolder(baseFolder);
-                    track.setChanged(lastModified);
-                    track.setLastScanned(Instant.now());
-                    track.setChildrenLastUpdated(childrenLastUpdated);
-                    track.setCreated(lastModified);
-                    track.setPresent(true);
-                    track.setTrackNumber(trackData.getNumber());
-                    track.setDiscNumber(base.getDiscNumber());
-                    track.setGenre(base.getGenre());
-                    track.setYear(base.getYear());
-                    track.setBitRate(base.getBitRate());
-                    track.setVariableBitRate(base.isVariableBitRate());
-                    track.setHeight(base.getHeight());
-                    track.setWidth(base.getWidth());
-                    track.setFormat(base.getFormat());
-                    track.setStartPosition(currentStart);
-                    track.setDuration(duration);
-                    // estimate file size based on duration and whole file size
-                    long estimatedSize = (long) (duration / wholeFileLength * wholeFileSize);
-                    // if estimated size is within of whole file size, use it. Otherwise use whole file size divided by number of tracks
-                    if (estimatedSize > 0 && estimatedSize <= wholeFileSize) {
-                        track.setFileSize(estimatedSize);
-                    } else {
-                        track.setFileSize((long)(wholeFileSize / trackSize));
-                    }
-                    track.setPlayCount((existingFile == null) ? 0 : existingFile.getPlayCount());
-                    track.setLastPlayed((existingFile == null) ? null : existingFile.getLastPlayed());
-                    track.setComment((existingFile == null) ? null : existingFile.getComment());
-                    track.setMediaType(mediaType);
+                track.setPlayCount((existingFile == null) ? 0 : existingFile.getPlayCount());
+                track.setLastPlayed((existingFile == null) ? null : existingFile.getLastPlayed());
+                track.setComment((existingFile == null) ? null : existingFile.getComment());
+                track.setMediaType(mediaType);
 
-                    updateMediaFile(track);
-                }
+                updateMediaFile(track);
 
                 children.add(track);
             }
@@ -1295,6 +1302,24 @@ public class MediaFileService {
     private List<MediaFile> createIndexedTracks(MediaFile base) {
         CueSheet cueSheet = getCueSheet(base);
         return createIndexedTracks(base, cueSheet);
+    }
+
+    private FileData getFileDataForBase(@Nonnull MediaFile base, @Nullable CueSheet cueSheet) {
+        if (Objects.isNull(cueSheet)) {
+            return null;
+        }
+
+        String baseFileName = FilenameUtils.getName(base.getPath());
+        return cueSheet.getFileData().stream()
+                .filter(fileData -> FilenameUtils.getName(fileData.getFile()).equals(baseFileName))
+                .findFirst()
+                .orElseGet(() -> cueSheet.getFileData().isEmpty() ? null : cueSheet.getFileData().get(0));
+    }
+
+    private double getStartPosition(TrackData trackData) {
+        Position position = trackData.getIndices().get(0).getPosition();
+        // convert CUE timestamp (minutes:seconds:frames, 75 frames/second) to fractional seconds
+        return position.getMinutes() * 60 + position.getSeconds() + (position.getFrames() / 75.0);
     }
 
     private MediaFile.MediaType getMediaType(MediaFile mediaFile) {
@@ -1367,11 +1392,8 @@ public class MediaFileService {
                         LOG.warn("Defaulting to UTF-8 for cuesheet {}", cueFile);
                     }
                     if (cueSheet != null) {
-                        if (cueSheet.getMessages().stream().filter(m -> m.toString().toLowerCase().contains("warning"))
-                                .map(m -> {
-                                    LOG.warn("Parsing {} at line {} : {}", cueFile, m.getLineNumber(), m.getMessage());
-                                    return m;
-                                }).findFirst().isPresent()) {
+                        cueSheet.getMessages().forEach(m -> LOG.warn("Parsing {} at line {} : {}", cueFile, m.getLineNumber(), m.getMessage()));
+                        if (cueSheet.getMessages().stream().anyMatch(m -> m instanceof org.digitalmediaserver.cuelib.Error)) {
                             cueSheet = null;
                         }
                     }
@@ -1389,6 +1411,15 @@ public class MediaFileService {
                     LOG.warn("Error parsing cuesheet {}", cueFile);
                 }
                 return null;
+            }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Parsed cuesheet {} with {} file block(s) and {} track(s)", cueFile,
+                        cueSheet.getFileData().size(), cueSheet.getAllTrackData().size());
+                for (FileData fileData : cueSheet.getFileData()) {
+                    LOG.debug("Parsed cuesheet {} FILE '{}' type '{}' track numbers {}", cueFile,
+                            fileData.getFile(), fileData.getFileType(), fileData.getTrackData().stream()
+                                    .map(TrackData::getNumber).collect(Collectors.toList()));
+                }
             }
             return cueSheet;
         } catch (IOException e) {

--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaFileServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaFileServiceTest.java
@@ -22,8 +22,14 @@ import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.domain.MediaFile.MediaType;
 import org.airsonic.player.domain.MusicFolder;
 import org.airsonic.player.repository.MediaFileRepository;
+import org.airsonic.player.repository.MusicFileInfoRepository;
 import org.airsonic.player.service.cache.MediaFileCache;
 import org.airsonic.player.service.metadata.MetaDataParserFactory;
+import org.digitalmediaserver.cuelib.CueSheet;
+import org.digitalmediaserver.cuelib.FileData;
+import org.digitalmediaserver.cuelib.Index;
+import org.digitalmediaserver.cuelib.Position;
+import org.digitalmediaserver.cuelib.TrackData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,8 +40,11 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -55,6 +64,10 @@ public class MediaFileServiceTest {
     private MediaFileCache mediaFileCache;
     @Mock
     private MediaFolderService mediaFolderService;
+    @Mock
+    private MusicFileInfoRepository musicFileInfoRepository;
+    @Mock
+    private SettingsService settingsService;
 
     @InjectMocks
     private MediaFileService mediaFileService;
@@ -97,5 +110,99 @@ public class MediaFileServiceTest {
         verify(mediaFileRepository).findByFolderAndPath(any(), eq("valid/airsonic-test.wav"));
         verify(mediaFileRepository).save(base);
         verify(coverArtService).persistIfNeeded(eq(base));
+    }
+
+    @Test
+    public void createIndexedTracksUsesOnlyTracksFromMatchingCueFileData() {
+        CueSheet cueSheet = new CueSheet();
+        cueSheet.setTitle("Album");
+        cueSheet.setPerformer("Album Artist");
+
+        FileData otherFileData = new FileData(cueSheet, "airsonic-test.wav", "WAVE");
+        otherFileData.getTrackData().add(createTrack(otherFileData, 1, "Wrong File Track", 0, 0, 0));
+        cueSheet.getFileData().add(otherFileData);
+
+        FileData matchingFileData = new FileData(cueSheet, "piano.mp3", "MP3");
+        matchingFileData.getTrackData().add(createTrack(matchingFileData, 2, "Matching Track 1", 0, 0, 0));
+        matchingFileData.getTrackData().add(createTrack(matchingFileData, 3, "Matching Track 2", 0, 10, 37));
+        cueSheet.getFileData().add(matchingFileData);
+
+        MediaFile base = new MediaFile();
+        base.setIndexPath("cue/airsonic-test.cue");
+        base.setPath("piano.mp3");
+        base.setMediaType(MediaType.MUSIC);
+        base.setFormat("mp3");
+        base.setDuration(30.0);
+        base.setFolder(mockedFolder);
+        base.setChanged(Instant.now());
+        base.setLastScanned(Instant.now());
+        base.setCreated(Instant.now());
+
+        when(mediaFileRepository.findByFolderAndPath(any(), eq("piano.mp3"))).thenReturn(List.of());
+        when(mediaFileRepository.findByPathAndFolderAndStartPosition(any(), any(), any())).thenReturn(Optional.empty());
+        when(musicFileInfoRepository.findByPath(any())).thenReturn(Optional.empty());
+
+        List<MediaFile> actual = ReflectionTestUtils.invokeMethod(mediaFileService, "createIndexedTracks", base, cueSheet);
+
+        assertEquals(2, actual.size());
+        assertEquals("Matching Track 1", actual.get(0).getTitle());
+        assertEquals("Matching Track 2", actual.get(1).getTitle());
+        assertEquals("piano.mp3", actual.get(0).getPath());
+        assertEquals("piano.mp3", actual.get(1).getPath());
+        assertEquals(0.0d, actual.get(0).getStartPosition(), 0.0d);
+        assertEquals(10.493d, actual.get(1).getStartPosition(), 0.001d);
+        assertEquals(10.493d, actual.get(0).getDuration(), 0.001d);
+        assertEquals(19.506d, actual.get(1).getDuration(), 0.001d);
+    }
+
+    @Test
+    public void createIndexedTracksRefreshesExistingCueTrackMetadataAndDuration() {
+        CueSheet cueSheet = new CueSheet();
+        cueSheet.setTitle("Album");
+        cueSheet.setPerformer("Album Artist");
+
+        FileData fileData = new FileData(cueSheet, "piano.mp3", "MP3");
+        fileData.getTrackData().add(createTrack(fileData, 2, "Fresh Title", 0, 0, 0));
+        cueSheet.getFileData().add(fileData);
+
+        MediaFile base = new MediaFile();
+        base.setIndexPath("cue/airsonic-test.cue");
+        base.setPath("piano.mp3");
+        base.setMediaType(MediaType.MUSIC);
+        base.setFormat("mp3");
+        base.setDuration(30.0);
+        base.setFolder(mockedFolder);
+        base.setChanged(Instant.now());
+        base.setLastScanned(Instant.now());
+        base.setCreated(Instant.now());
+
+        MediaFile staleTrack = new MediaFile();
+        staleTrack.setId(42);
+        staleTrack.setPath("piano.mp3");
+        staleTrack.setFolder(mockedFolder);
+        staleTrack.setStartPosition(0.0);
+        staleTrack.setDuration(10.0);
+        staleTrack.setTitle("Stale Title");
+        staleTrack.setTrackNumber(5);
+        staleTrack.setPlayCount(7);
+
+        when(mediaFileRepository.findByFolderAndPath(any(), eq("piano.mp3"))).thenReturn(List.of(staleTrack));
+        when(mediaFileRepository.existsById(eq(42))).thenReturn(true);
+
+        List<MediaFile> actual = ReflectionTestUtils.invokeMethod(mediaFileService, "createIndexedTracks", base, cueSheet);
+
+        assertEquals(1, actual.size());
+        assertEquals("Fresh Title", actual.get(0).getTitle());
+        assertEquals(2L, (long)actual.get(0).getTrackNumber());
+        assertEquals(30.0d, actual.get(0).getDuration(), 0.001d);
+        assertEquals(7, actual.get(0).getPlayCount());
+        verify(mediaFileRepository).save(staleTrack);
+    }
+
+    private TrackData createTrack(FileData fileData, int number, String title, int minutes, int seconds, int frames) {
+        TrackData trackData = new TrackData(fileData, number, "AUDIO");
+        trackData.setTitle(title);
+        trackData.getIndices().add(new Index(1, new Position(minutes, seconds, frames)));
+        return trackData;
     }
 }


### PR DESCRIPTION
  ## Summary

  Fixes indexed-track creation for external CUE sheets that contain multiple `FILE` blocks.

  Previously Airsonic resolved only the first `FILE` entry in a CUE sheet, then iterated all tracks globally. For multifile CUE sheets this attached later virtual tracks to the wrong physical audio file and produced incorrect durations.

  ## Changes

  - Processes each CUE `FileData` block independently.
  - Resolves each `FILE` block to its own physical media file.
  - Creates indexed tracks only from that file block's `TrackData`.
  - Calculates duration relative to the next track in the same `FILE` block.
  - Uses the physical file length for the final track in a file block.
  - Preserves fractional CUE frame timing.
  - Refreshes stale indexed-track metadata on rescan while preserving playback state.

  ## Testing

  ```sh
  PATH=/opt/apache-maven-3.9.15/bin:$PATH \
  mvn -pl airsonic-main -am \
    -Dtest=MediaFileServiceTest \
    -Dsurefire.failIfNoSpecifiedTests=false \
    test

  Result:

  BUILD SUCCESS
  Tests run: 3, Failures: 0, Errors: 0, Skipped: 0