### PR TITLE
Add FreeBSD rc.d service script and docs (contrib/freebsd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ You need a _minimum_ Java Runtime Environment (JRE) of 1.8 for 10.6.x series, an
 
 Airsonic-Advanced is run similarly to (and in lieu of) vanilla Airsonic.
 
+On FreeBSD, an `rc.d` service script and setup instructions are available in [`contrib/freebsd`](./contrib/freebsd).
+
 Read the [compatibility notes](#compatibility-notes).
 
 ### Docker

--- a/contrib/freebsd/README.md
+++ b/contrib/freebsd/README.md
@@ -1,0 +1,90 @@
+# Running Airsonic-Advanced on FreeBSD
+
+FreeBSD does not use systemd. This directory ships an `rc.d` service script
+(`airsonic`) that is the FreeBSD counterpart to `contrib/airsonic.service`. It
+exposes the same knobs, only as `rc.conf` variables.
+
+The instructions below assume a stand-alone `.war` (see the *Stand-alone
+binaries* section of the main README), not the Docker image.
+
+## 1. Install a JRE
+
+Airsonic-Advanced 11.x needs Java 17 or newer:
+
+```sh
+pkg install openjdk21
+```
+
+> **Note:** FreeBSD installs each JDK under `/usr/local/openjdkNN/bin/java`.
+> The generic `/usr/local/bin/java` wrapper may resolve to an *older* JDK if
+> several are installed (e.g. `openjdk8`), which Airsonic will refuse to run on.
+> When in doubt, pin `airsonic_java` to the explicit path (see below).
+
+## 2. Create a dedicated user
+
+```sh
+pw groupadd airsonic
+pw useradd airsonic -g airsonic -d /var/airsonic -s /usr/sbin/nologin -c "Airsonic Media Server"
+```
+
+## 3. Place the war and data directory
+
+```sh
+mkdir -p /var/airsonic
+fetch -o /var/airsonic/airsonic.war \
+  https://github.com/kagemomiji/airsonic-advanced/releases/latest/download/airsonic.war
+chown -R airsonic:airsonic /var/airsonic
+```
+
+## 4. Install the service script
+
+```sh
+install -m 0755 contrib/freebsd/airsonic /usr/local/etc/rc.d/airsonic
+```
+
+## 5. Configure and enable
+
+Add the settings you need to `/etc/rc.conf` (only `airsonic_enable` is
+required, everything else has a sensible default):
+
+```sh
+sysrc airsonic_enable="YES"
+sysrc airsonic_java="/usr/local/openjdk21/bin/java"
+sysrc airsonic_java_opts="-Xmx1g"
+sysrc airsonic_port="4040"
+sysrc airsonic_context_path="/"
+```
+
+Then start it:
+
+```sh
+service airsonic start
+service airsonic status
+```
+
+## Available rc.conf variables
+
+| Variable                  | Default                      | systemd equivalent          |
+|---------------------------|------------------------------|-----------------------------|
+| `airsonic_enable`         | `NO`                         | (enable the unit)           |
+| `airsonic_home`           | `/var/airsonic`              | `AIRSONIC_HOME`             |
+| `airsonic_war`            | `${airsonic_home}/airsonic.war` | `JAVA_JAR`               |
+| `airsonic_user`           | `airsonic`                   | `User`                      |
+| `airsonic_group`          | `airsonic`                   | `Group`                     |
+| `airsonic_java`           | `/usr/local/bin/java`        | (the `java` binary)         |
+| `airsonic_java_opts`      | `-Xmx700m`                   | `JAVA_OPTS`                 |
+| `airsonic_port`           | `8080`                       | `PORT`                      |
+| `airsonic_context_path`   | `/airsonic`                  | `CONTEXT_PATH`              |
+| `airsonic_args`           | (empty)                      | `JAVA_ARGS`                 |
+| `airsonic_log`            | `/var/log/airsonic.log`      | (journald)                  |
+
+## Behind a reverse proxy
+
+Airsonic talks to its Web UI over websockets, so the proxy has to allow
+`Upgrade` requests, and the server needs `server.forward-headers-strategy=native`.
+This is not FreeBSD-specific — see the *Compatibility Notes* in the main README.
+You can pass the property through `airsonic_args`, e.g.:
+
+```sh
+sysrc airsonic_args="--server.forward-headers-strategy=native"
+```

--- a/contrib/freebsd/airsonic
+++ b/contrib/freebsd/airsonic
@@ -1,0 +1,88 @@
+#!/bin/sh
+#
+# PROVIDE: airsonic
+# REQUIRE: LOGIN NETWORKING
+# KEYWORD: shutdown
+#
+# Airsonic Media Server rc.d script for FreeBSD.
+#
+# Add the following line to /etc/rc.conf to enable airsonic:
+#
+#   airsonic_enable="YES"
+#
+# The following variables are optional (defaults shown). They mirror the knobs
+# exposed by the systemd unit in contrib/airsonic.service:
+#
+#   airsonic_home="/var/airsonic"            # AIRSONIC_HOME / -Dairsonic.home
+#   airsonic_war="/var/airsonic/airsonic.war"# JAVA_JAR
+#   airsonic_user="airsonic"                 # user the server runs as
+#   airsonic_group="airsonic"                # group the server runs as
+#   airsonic_java="/usr/local/bin/java"      # path to the JRE (JDK 17+)
+#   airsonic_java_opts="-Xmx700m"            # JAVA_OPTS (heap, GC, ...)
+#   airsonic_port="8080"                     # PORT / -Dserver.port
+#   airsonic_context_path="/airsonic"        # CONTEXT_PATH / context-path
+#   airsonic_args=""                         # JAVA_ARGS (passed to the app)
+#   airsonic_log="/var/log/airsonic.log"     # stdout/stderr log file
+#
+# Notes:
+#   * Requires an OpenJDK package (e.g. openjdk21). FreeBSD installs the JRE
+#     under /usr/local/openjdkNN/bin/java; if /usr/local/bin/java does not
+#     exist, set airsonic_java accordingly, e.g.
+#       airsonic_java="/usr/local/openjdk21/bin/java"
+#   * Privilege drop is handled by daemon(8) (-u). Do NOT also set a login
+#     class / rc.subr user drop for this service: combining both fails with
+#     "daemon: open: Permission denied".
+
+. /etc/rc.subr
+
+name="airsonic"
+rcvar="airsonic_enable"
+
+load_rc_config "$name"
+
+: ${airsonic_enable:="NO"}
+: ${airsonic_home:="/var/airsonic"}
+: ${airsonic_war:="${airsonic_home}/airsonic.war"}
+: ${airsonic_user:="airsonic"}
+: ${airsonic_group:="airsonic"}
+: ${airsonic_java:="/usr/local/bin/java"}
+: ${airsonic_java_opts:="-Xmx700m"}
+: ${airsonic_port:="8080"}
+: ${airsonic_context_path:="/airsonic"}
+: ${airsonic_args:=""}
+: ${airsonic_log:="/var/log/${name}.log"}
+
+pidfile="/var/run/${name}/${name}.pid"
+procname="${airsonic_java}"
+
+start_precmd="airsonic_precmd"
+start_cmd="airsonic_start"
+
+airsonic_precmd()
+{
+	# pidfile directory, owned by the run user so daemon(8) can write it
+	if [ ! -d "/var/run/${name}" ]; then
+		install -d -o "${airsonic_user}" -g "${airsonic_group}" -m 0755 \
+			"/var/run/${name}"
+	fi
+	# log file, writable by the run user
+	if [ ! -e "${airsonic_log}" ]; then
+		install -o "${airsonic_user}" -g "${airsonic_group}" -m 0640 \
+			/dev/null "${airsonic_log}"
+	fi
+}
+
+airsonic_start()
+{
+	check_startmsgs && echo "Starting ${name}."
+	/usr/sbin/daemon -f -u "${airsonic_user}" \
+		-p "${pidfile}" -o "${airsonic_log}" \
+		"${airsonic_java}" ${airsonic_java_opts} \
+		-Djava.awt.headless=true \
+		-Dairsonic.home="${airsonic_home}" \
+		-Dserver.servlet.context-path="${airsonic_context_path}" \
+		-Dserver.port="${airsonic_port}" \
+		-jar "${airsonic_war}" ${airsonic_args}
+}
+
+run_rc_command "$1"


### PR DESCRIPTION
## Add a FreeBSD rc.d service

FreeBSD doesn't use systemd, so `contrib/airsonic.service` doesn't help there and right now there's no supported way to run Airsonic-Advanced as a managed service on FreeBSD. This PR adds the FreeBSD counterpart.

**What's included**
- `contrib/freebsd/airsonic` — an `rc.d` script that mirrors the exact knobs of the systemd unit, just as `rc.conf` variables (`airsonic_home`, `airsonic_war`, `airsonic_java_opts`, `airsonic_port`, `airsonic_context_path`, `airsonic_args`, `airsonic_user`/`group`, `airsonic_log`). Same defaults as the unit (`/var/airsonic`, port 8080, context `/airsonic`, user `airsonic`, `-Xmx700m`).
- `contrib/freebsd/README.md` — a short howto (pkg install openjdk, create user, enable via `sysrc`, reverse-proxy note).
- A one-line pointer from the README's *Stand-alone binaries* section.

Privilege drop is done by `daemon(8) -u` rather than rc.subr's own user drop — combining the two fails on FreeBSD with `daemon: open: Permission denied`, so the script uses a custom `start_cmd`. `stop`/`status` use the standard rc.subr handling via `pidfile` + `procname`.

**Testing**
Tested on FreeBSD 15.1 (inside a jail) against the 11.1.4 war on OpenJDK 21: `service airsonic start`/`status`/`stop` all behave correctly, the process drops to the unprivileged user, the pidfile is written and cleaned up, and a graceful SIGTERM shutdown works.

Scope is deliberately kept minimal per CONTRIBUTING (one new directory, tiny README pointer, no functional code touched).

---

A bit of context, since I'd rather not just drop code anonymously: I ran the original Subsonic privately for many years, but with it no longer being maintained I recently moved to your fork — it looks by far the most current and alive of the bunch. I almost always run it on FreeBSD, which is what motivated this contribution: I'd genuinely like to keep using this setup long-term. It does everything I need for a private install, especially together with [DSub2000](https://github.com/paroj/DSub2000) on the Android side for friends and family.

Honestly — thank you for forking this and keeping it alive. The original Subsonic and vanilla Airsonic both quietly died on their users, and without someone picking this up and actually caring for it, people like me would have been left stranded. The fact that you took it on and clearly keep an eye on it means a great deal, and it's a big part of why I'd rather contribute back than just consume. So a heartfelt thank you, @kagemomiji — really.
