### PR TITLE
fix: use loadedmetadata event to reliably restore bookmark position

### DIFF
--- a/airsonic-main/src/main/resources/templates/playQueue.html
+++ b/airsonic-main/src/main/resources/templates/playQueue.html
@@ -873,18 +873,15 @@
                         // Inform MEJS that we need to load a new media source. The
                         // 'canplay' event will be fired once playback is possible.
                         player.load();
-                        // The 'skip' function takes a 'position' argument. We don't
-                        // usually send it, and in this case it's better to do nothing.
-                        // Otherwise, the 'canplay' event will also be fired after
-                        // setting 'currentTime'.
                         if (position && position > 0) {
-                            player.currentTime = position;
+                            player.node.addEventListener('loadedmetadata', function onLoaded() {
+                                player.currentTime = position;
+                                player.node.removeEventListener('loadedmetadata', onLoaded);
+                            });
                         }
-                    
+
                     // Are we seeking on an already-playing song?
                     } else {
-                        // Seeking also starts playing. The 'canplay' event will be
-                        // fired after setting 'currentTime'.
                         player.currentTime = position || 0;
                     }
                 


### PR DESCRIPTION
## Problem

When resuming playback from a saved bookmark position, `player.currentTime = position` is set immediately after `player.load()`. This is a race condition -- the audio element may not yet have loaded metadata (duration, seekable ranges), so the seek is silently ignored and playback always starts from 0:00.

## Fix

Defer the seek until the `loadedmetadata` event fires, then remove the listener so it only triggers once. The `else` branch (seeking on an already-playing track) is unaffected -- metadata is already loaded in that case.

```diff
 if (position && position > 0) {
-    player.currentTime = position;
+    player.node.addEventListener('loadedmetadata', function onLoaded() {
+        player.currentTime = position;
+        player.node.removeEventListener('loadedmetadata', onLoaded);
+    });
 }
```

## Testing

- Play a track, seek to arbitrary position, pause
- Reload the page
- Hit play -- playback resumes at the saved position reliably

Tested with podcast episodes (2-3hr files) and music tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)