### PR TITLE
fix: bump aquasecurity/trivy-action from 0.33.1 to 0.36.0

### DIFF
--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           scan-type: 'fs'
           format: 'sarif'


### PR DESCRIPTION
Fixes #822.

`aquasecurity/trivy-action@0.33.1` executed a compromised SHA during the recent Trivy incident. This bumps to `0.36.0`, a clean post-incident release.

One-line diff:
```
- uses: aquasecurity/trivy-action@0.33.1
+ uses: aquasecurity/trivy-action@0.36.0
```

If you prefer SHA pinning for extra hardening:
```yaml
uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37  # 0.36.0
```