### PR TITLE
perf: use native ubuntu-24.04-arm runner for linux/arm64 builds

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -40,7 +40,7 @@ jobs:
           name: build-metadata
           path: airsonic-main/target/generated/build-metadata/build.properties 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.cfg.runner }}
     needs: version
     strategy:
       fail-fast: false
@@ -49,12 +49,15 @@ jobs:
         - jdk: 17
           platform: linux/arm/v7
           docker_version: 17.0.15_6
+          runner: ubuntu-latest
         - jdk: 21
           platform: linux/amd64
           docker_version: 21.0.7_6
+          runner: ubuntu-latest
         - jdk: 21
           platform: linux/arm64
           docker_version: 21.0.7_6
+          runner: ubuntu-24.04-arm
     outputs:
       tag: ${{ steps.tagcalc.outputs.tag }}
     steps:
@@ -79,6 +82,7 @@ jobs:
           java-version: ${{ matrix.cfg.jdk }}
           distribution: 'temurin'
       - name: Set up QEMU
+        if: matrix.cfg.platform == 'linux/arm/v7'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: ${{ matrix.cfg.platform }}

--- a/.github/workflows/pr_build_docker.yml
+++ b/.github/workflows/pr_build_docker.yml
@@ -48,13 +48,16 @@ jobs:
         - jdk: 17
           platform: linux/arm/v7
           docker_version: 17.0.15_6
+          runner: ubuntu-latest
         - jdk: 21
           platform: linux/amd64
           docker_version: 21.0.7_6
+          runner: ubuntu-latest
         - jdk: 21
           platform: linux/arm64
           docker_version: 21.0.7_6
-    runs-on: ubuntu-latest
+          runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.cfg.runner }}
     if: github.repository == github.event.pull_request.head.repo.full_name 
     steps:
       - name: Prepare
@@ -91,6 +94,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
       - name: Set up QEMU
+        if: matrix.cfg.platform == 'linux/arm/v7'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: ${{ matrix.cfg.platform }}

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.cfg.runner }}
     strategy:
       fail-fast: false
       matrix:
@@ -17,12 +17,15 @@ jobs:
         - jdk: 17
           platform: linux/arm/v7
           docker_version: 17.0.15_6
+          runner: ubuntu-latest
         - jdk: 21
           platform: linux/amd64
           docker_version: 21.0.7_6
+          runner: ubuntu-latest
         - jdk: 21
           platform: linux/arm64
           docker_version: 21.0.7_6
+          runner: ubuntu-24.04-arm
     if: startsWith(github.ref, 'refs/heads/stable/')
     outputs:
       tag: ${{ steps.tagcalc.outputs.tag }}
@@ -41,6 +44,7 @@ jobs:
           java-version: ${{matrix.cfg.jdk}}
           distribution: 'temurin'
       - name: Set up QEMU
+        if: matrix.cfg.platform == 'linux/arm/v7'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: ${{matrix.cfg.platform}}


### PR DESCRIPTION
## What

Replace QEMU emulation for `linux/arm64` with GitHub's native ARM64 hosted runner (`ubuntu-24.04-arm`) in `edge.yml`, `stable.yml`, and `pr_build_docker.yml`.

QEMU is kept only for `linux/arm/v7` — no native armv7 runner is available on GitHub.

## Why

QEMU arm64 emulation on an x86 runner is ~5-10x slower than native. In practice this means arm64 Docker builds + Maven compilation take 15-20 minutes under emulation vs ~3-5 minutes on a native runner. The `ubuntu-24.04-arm` runner is available as a standard GitHub-hosted runner on public repos at no extra cost.

## Change

Each workflow matrix entry gains a `runner` field:

```yaml
matrix:
  cfg:
  - platform: linux/arm/v7
    runner: ubuntu-latest      # QEMU still needed, no native armv7
  - platform: linux/amd64
    runner: ubuntu-latest
  - platform: linux/arm64
    runner: ubuntu-24.04-arm   # native, no QEMU
```

The QEMU setup step gets an `if: matrix.cfg.platform == 'linux/arm/v7'` guard so it only runs where needed.

## Affected files

- `.github/workflows/edge.yml`
- `.github/workflows/stable.yml`
- `.github/workflows/pr_build_docker.yml`