### PR TITLE
fix: add target=_top to logout form so redirect loads full window

### DIFF
--- a/airsonic-main/src/main/resources/templates/top.html
+++ b/airsonic-main/src/main/resources/templates/top.html
@@ -206,7 +206,7 @@
         </td>
 
     </tr></table>
-    <form id="logoutForm" th:action="@{/logout}"  method="POST" style="display:none">
+    <form id="logoutForm" th:action="@{/logout}" method="POST" style="display:none" target="_top">
     </form>
 
 </body></html>


### PR DESCRIPTION
Fixes #819.

## Root cause

The logout form lives in `top.html`, which is a frame inside a frameset. When the form POSTs to `/logout`, Spring Security invalidates the session and redirects to `/login?logout`. Without `target="_top"`, that redirect navigates only the top frame — the rest of the frameset stays intact, and the user sees the "disconnected" indicator but not the login page.

On a second logout click the CSRF token is stale (session was already invalidated by the first POST), resulting in the 403.

## Fix

One attribute on the form:

```html
<form id="logoutForm" th:action="@{/logout}" method="POST" style="display:none" target="_top">
```

`target="_top"` causes the browser to load the redirect response into the top-level browsing context (the full window) instead of just the frame.