### PR TITLE
fix: recheck non-present files during scan so remounts restore present=true

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -266,6 +266,7 @@ public class MediaFileService {
                 && (mediaFile.getVersion() < MediaFile.VERSION
                     || settingsService.getFullScan()
                     || mediaFile.isChanged()
+                    || !mediaFile.isPresent() // always recheck absent files so remounted paths recover
                     || (mediaFile.hasIndex() && mediaFile.getChanged().truncatedTo(ChronoUnit.MICROS).compareTo(FileUtil.lastModified(mediaFile.getFullIndexPath()).truncatedTo(ChronoUnit.MICROS)) < 0)
                 );
     }

--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaFileServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaFileServiceTest.java
@@ -36,6 +36,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -55,6 +56,8 @@ public class MediaFileServiceTest {
     private MediaFileCache mediaFileCache;
     @Mock
     private MediaFolderService mediaFolderService;
+    @Mock
+    private SettingsService settingsService;
 
     @InjectMocks
     private MediaFileService mediaFileService;
@@ -97,5 +100,31 @@ public class MediaFileServiceTest {
         verify(mediaFileRepository).findByFolderAndPath(any(), eq("valid/airsonic-test.wav"));
         verify(mediaFileRepository).save(base);
         verify(coverArtService).persistIfNeeded(eq(base));
+    }
+
+    @Test
+    public void testNonPresentFileForcesNeedsUpdate() {
+        when(mockedMediaFile.isPresent()).thenReturn(false);
+        when(mockedMediaFile.isIndexedTrack()).thenReturn(false);
+        when(mockedMediaFile.getVersion()).thenReturn(MediaFile.VERSION);
+        when(settingsService.getFullScan()).thenReturn(false);
+        when(mockedMediaFile.isChanged()).thenReturn(false);
+        when(mockedMediaFile.hasIndex()).thenReturn(false);
+
+        Boolean result = ReflectionTestUtils.invokeMethod(mediaFileService, "needsUpdate", mockedMediaFile, false);
+        assertTrue(result, "Non-present file must trigger needsUpdate so remounted paths recover to present=true");
+    }
+
+    @Test
+    public void testPresentFileWithNoChangesDoesNotNeedUpdate() {
+        when(mockedMediaFile.isPresent()).thenReturn(true);
+        when(mockedMediaFile.isIndexedTrack()).thenReturn(false);
+        when(mockedMediaFile.getVersion()).thenReturn(MediaFile.VERSION);
+        when(settingsService.getFullScan()).thenReturn(false);
+        when(mockedMediaFile.isChanged()).thenReturn(false);
+        when(mockedMediaFile.hasIndex()).thenReturn(false);
+
+        Boolean result = ReflectionTestUtils.invokeMethod(mediaFileService, "needsUpdate", mockedMediaFile, false);
+        assertFalse(result, "Present up-to-date file should not trigger needsUpdate");
     }
 }


### PR DESCRIPTION
Fixes #767.

## Root cause

`needsUpdate()` short-circuits when a file's mtime matches what's in the database. This is correct for up-to-date present files, but wrong for `present=false` files: when a mount drops, `markNonPresent` sets `present=false`. When the mount comes back, the file's mtime is unchanged — so `needsUpdate` returns `false`, `checkLastModified` returns early without touching `present`, and the file stays absent forever. Starred tracks and ratings are preserved in the DB but the file is permanently invisible.

## Fix

One condition added to `needsUpdate`:

```java
|| !mediaFile.isPresent() // always recheck absent files so remounted paths recover
```

This forces the full `checkLastModified` path for any `present=false` file, which calls `updateMediaFileByFile` and sets `present=true` when the file is found on disk. Files that are genuinely gone (mount still down) continue to be marked `present=false` as before.