### PR TITLE
fix: match split genres when browsing songs and albums by genre

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/repository/AlbumRepository.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/repository/AlbumRepository.java
@@ -4,6 +4,7 @@ import org.airsonic.player.domain.Album;
 import org.airsonic.player.domain.MusicFolder;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -17,7 +18,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @Repository
-public interface AlbumRepository extends JpaRepository<Album, Integer> {
+public interface AlbumRepository extends JpaRepository<Album, Integer>, org.springframework.data.jpa.repository.JpaSpecificationExecutor<Album> {
 
     public Optional<Album> findByArtistAndName(String artist, String name);
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/AlbumService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/AlbumService.java
@@ -221,10 +221,10 @@ public class AlbumService {
         }
         OffsetBasedPageRequest pageRequest = new OffsetBasedPageRequest(offset, count, Sort.by(Order.asc("id")));
         String separators = settingsService.getGenreSeparators();
-        Specification<Album> spec = buildGenreSpec(genre, separators)
+        Specification<Album> spec = this.<Album>buildGenreSpec(genre, separators)
             .and((root, q, cb) -> root.get("folder").in(musicFolders))
             .and((root, q, cb) -> cb.isTrue(root.get("present")));
-        return albumRepository.findAll(spec, pageRequest);
+        return albumRepository.findAll(spec, pageRequest).getContent();
     }
 
     private <T> Specification<T> buildGenreSpec(String genre, String separators) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/AlbumService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/AlbumService.java
@@ -236,6 +236,8 @@ public class AlbumService {
                 preds.add(cb.like(root.get("genre"), genre + s + "%"));
                 preds.add(cb.like(root.get("genre"), "%" + s + genre + s + "%"));
                 preds.add(cb.like(root.get("genre"), "%" + s + genre));
+                preds.add(cb.like(root.get("genre"), "%" + s + " " + genre + s + "%"));
+                preds.add(cb.like(root.get("genre"), "%" + s + " " + genre));
             }
             return cb.or(preds.toArray(new Predicate[0]));
         };

--- a/airsonic-main/src/main/java/org/airsonic/player/service/AlbumService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/AlbumService.java
@@ -7,14 +7,19 @@ import org.airsonic.player.domain.entity.StarredAlbum;
 import org.airsonic.player.repository.AlbumRepository;
 import org.airsonic.player.repository.OffsetBasedPageRequest;
 import org.airsonic.player.repository.StarredAlbumRepository;
+import org.airsonic.player.service.SettingsService;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
+import jakarta.persistence.criteria.Predicate;
+
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -25,10 +30,12 @@ public class AlbumService {
 
     private final AlbumRepository albumRepository;
     private final StarredAlbumRepository starredAlbumRepository;
+    private final SettingsService settingsService;
 
-    public AlbumService(AlbumRepository albumRepository, StarredAlbumRepository starredAlbumRepository) {
+    public AlbumService(AlbumRepository albumRepository, StarredAlbumRepository starredAlbumRepository, SettingsService settingsService) {
         this.albumRepository = albumRepository;
         this.starredAlbumRepository = starredAlbumRepository;
+        this.settingsService = settingsService;
     }
 
     /**
@@ -213,9 +220,25 @@ public class AlbumService {
             return Collections.emptyList();
         }
         OffsetBasedPageRequest pageRequest = new OffsetBasedPageRequest(offset, count, Sort.by(Order.asc("id")));
+        String separators = settingsService.getGenreSeparators();
+        Specification<Album> spec = buildGenreSpec(genre, separators)
+            .and((root, q, cb) -> root.get("folder").in(musicFolders))
+            .and((root, q, cb) -> cb.isTrue(root.get("present")));
+        return albumRepository.findAll(spec, pageRequest);
+    }
 
-        return albumRepository.findByGenreAndFolderInAndPresentTrue(genre, musicFolders,
-                pageRequest);
+    private <T> Specification<T> buildGenreSpec(String genre, String separators) {
+        return (root, q, cb) -> {
+            List<Predicate> preds = new ArrayList<>();
+            preds.add(cb.equal(root.get("genre"), genre));
+            for (char sep : separators.toCharArray()) {
+                String s = String.valueOf(sep);
+                preds.add(cb.like(root.get("genre"), genre + s + "%"));
+                preds.add(cb.like(root.get("genre"), "%" + s + genre + s + "%"));
+                preds.add(cb.like(root.get("genre"), "%" + s + genre));
+            }
+            return cb.or(preds.toArray(new Predicate[0]));
+        };
     }
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -61,6 +61,7 @@ import org.springframework.context.MessageSource;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
@@ -68,6 +69,7 @@ import org.springframework.util.CollectionUtils;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import jakarta.persistence.criteria.Predicate;
 
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
@@ -428,7 +430,26 @@ public class MediaFileService {
         if (CollectionUtils.isEmpty(musicFolders)) {
             return Collections.emptyList();
         }
-        return mediaFileRepository.findByFolderInAndMediaTypeInAndGenreAndPresentTrue(musicFolders, MediaType.audioTypes(), genre, new OffsetBasedPageRequest(offset, count, Sort.by("id")));
+        String separators = settingsService.getGenreSeparators();
+        Specification<MediaFile> spec = buildGenreSpec(genre, separators)
+            .and((root, q, cb) -> root.get("folder").in(musicFolders))
+            .and((root, q, cb) -> root.get("mediaType").in(MediaType.audioTypes()))
+            .and((root, q, cb) -> cb.isTrue(root.get("present")));
+        return mediaFileRepository.findAll(spec, new OffsetBasedPageRequest(offset, count, Sort.by("id")));
+    }
+
+    private <T> Specification<T> buildGenreSpec(String genre, String separators) {
+        return (root, q, cb) -> {
+            List<Predicate> preds = new ArrayList<>();
+            preds.add(cb.equal(root.get("genre"), genre));
+            for (char sep : separators.toCharArray()) {
+                String s = String.valueOf(sep);
+                preds.add(cb.like(root.get("genre"), genre + s + "%"));
+                preds.add(cb.like(root.get("genre"), "%" + s + genre + s + "%"));
+                preds.add(cb.like(root.get("genre"), "%" + s + genre));
+            }
+            return cb.or(preds.toArray(new Predicate[0]));
+        };
     }
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -447,6 +447,8 @@ public class MediaFileService {
                 preds.add(cb.like(root.get("genre"), genre + s + "%"));
                 preds.add(cb.like(root.get("genre"), "%" + s + genre + s + "%"));
                 preds.add(cb.like(root.get("genre"), "%" + s + genre));
+                preds.add(cb.like(root.get("genre"), "%" + s + " " + genre + s + "%"));
+                preds.add(cb.like(root.get("genre"), "%" + s + " " + genre));
             }
             return cb.or(preds.toArray(new Predicate[0]));
         };

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -431,11 +431,11 @@ public class MediaFileService {
             return Collections.emptyList();
         }
         String separators = settingsService.getGenreSeparators();
-        Specification<MediaFile> spec = buildGenreSpec(genre, separators)
+        Specification<MediaFile> spec = this.<MediaFile>buildGenreSpec(genre, separators)
             .and((root, q, cb) -> root.get("folder").in(musicFolders))
             .and((root, q, cb) -> root.get("mediaType").in(MediaType.audioTypes()))
             .and((root, q, cb) -> cb.isTrue(root.get("present")));
-        return mediaFileRepository.findAll(spec, new OffsetBasedPageRequest(offset, count, Sort.by("id")));
+        return mediaFileRepository.findAll(spec, new OffsetBasedPageRequest(offset, count, Sort.by("id"))).getContent();
     }
 
     private <T> Specification<T> buildGenreSpec(String genre, String separators) {

--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaFileServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaFileServiceTest.java
@@ -30,12 +30,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -55,6 +59,8 @@ public class MediaFileServiceTest {
     private MediaFileCache mediaFileCache;
     @Mock
     private MediaFolderService mediaFolderService;
+    @Mock
+    private SettingsService settingsService;
 
     @InjectMocks
     private MediaFileService mediaFileService;
@@ -97,5 +103,32 @@ public class MediaFileServiceTest {
         verify(mediaFileRepository).findByFolderAndPath(any(), eq("valid/airsonic-test.wav"));
         verify(mediaFileRepository).save(base);
         verify(coverArtService).persistIfNeeded(eq(base));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetSongsByGenreUsesFindAllWithSpecification() {
+        MediaFile song = new MediaFile();
+        song.setPath("songs/track.mp3");
+        song.setMediaType(MediaType.MUSIC);
+        song.setGenre("Dance; Edm; House");
+        song.setFolder(mockedFolder);
+
+        when(settingsService.getGenreSeparators()).thenReturn(";");
+        when(mediaFileRepository.findAll(any(Specification.class), any(Pageable.class)))
+                .thenReturn(List.of(song));
+
+        List<MediaFile> result = mediaFileService.getSongsByGenre(0, 10, "Dance", List.of(mockedFolder));
+
+        assertEquals(1, result.size());
+        assertEquals("Dance; Edm; House", result.get(0).getGenre());
+        verify(mediaFileRepository).findAll(any(Specification.class), any(Pageable.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetSongsByGenreEmptyFoldersReturnsEmpty() {
+        List<MediaFile> result = mediaFileService.getSongsByGenre(0, 10, "Dance", Collections.emptyList());
+        assertTrue(result.isEmpty());
     }
 }


### PR DESCRIPTION
Fixes #675, fixes #826.

## Problem

Genre tags like `"Dance; Edm; House"` are correctly split during scanning — `Genres.incrementSongCount` creates separate entries for `Dance`, `Edm`, `House`, and the original combined value, all with the right counts. But clicking a split genre in the UI calls `getSongsByGenre("Dance", ...)` which queries `WHERE genre = 'Dance'` — an exact match that returns nothing, because the stored value is `"Dance; Edm; House"`.

## Fix

Replace the exact-match queries in `getSongsByGenre` and `getAlbumsByGenre` with `Specification`-based LIKE predicates that check separator boundaries. For a genre `G` and separator `;`:

```
genre = 'G'
OR genre LIKE 'G;%'
OR genre LIKE '%;G;%'
OR genre LIKE '%;G'
```

The separator character(s) are read from the existing `GenreSeparators` setting (default `"; "`), so custom separators work automatically.

`AlbumRepository` gains `JpaSpecificationExecutor<Album>` to support the Specification approach for album browsing.

## Files changed

- `MediaFileService` — `getSongsByGenre` + `buildGenreSpec` helper
- `AlbumService` — `getAlbumsByGenre` + same `buildGenreSpec` helper, `SettingsService` wired in
- `AlbumRepository` — extends `JpaSpecificationExecutor<Album>`