### PR TITLE
fix: add MariaDB-specific Liquibase changeset to enable CUE track seeking

### DIFF
--- a/airsonic-main/src/main/resources/liquibase/11.0/cue-support.xml
+++ b/airsonic-main/src/main/resources/liquibase/11.0/cue-support.xml
@@ -93,4 +93,17 @@
         </update>
         <rollback changeSetId="schema50_003" changeSetAuthor="muff1nman" changeSetPath="classpath:liquibase/legacy/schema50.xml" />
     </changeSet>
+    <changeSet id="addsplittingtranscoder_001_mariadb" author="slmingol" dbms="mariadb">
+        <!-- MariaDB LIKE is case-insensitive by default so the !mysql changeset's precondition
+             matches the existing lowercase %s and skips the update. Use LIKE BINARY here to
+             distinguish %S (split placeholder) from %s (source file) correctly. -->
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from transcoding where name='mp3 audio' and step1 like binary '% %%S %'</sqlCheck>
+        </preConditions>
+        <update tableName="transcoding">
+            <column name="step1" value="ffmpeg %S -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -" />
+            <where>name='mp3 audio'</where>
+        </update>
+        <rollback changeSetId="schema50_003" changeSetAuthor="muff1nman" changeSetPath="classpath:liquibase/legacy/schema50.xml" />
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## Problem

When using MariaDB, all CUE sheet virtual tracks play from the beginning (track 1) regardless of which track is selected. The ffmpeg transcode command lacks a `-ss` seek offset.

Closes #789

## Root cause

Two Liquibase changesets in `cue-support.xml` update the `mp3 audio` transcoding rule to include `%S` (the CUE split-options placeholder that carries `-ss <offset> -t <duration>`):

| Changeset | `dbms` filter | Precondition |
|-----------|--------------|--------------|
| `addsplittingtranscoder_001` | `!mysql` | `step1 LIKE '% %%S %'` |
| `addsplittingtranscoder_001_mysql` | `mysql` | `step1 LIKE BINARY '% %%S %'` |

With the MariaDB JDBC driver (`jdbc:mariadb://`), Liquibase identifies the database type as `mariadb`, not `mysql`. Therefore:

- `addsplittingtranscoder_001` (`dbms="!mysql"`) **runs** on MariaDB. However, MariaDB's default `LIKE` is case-insensitive, so its precondition `LIKE '% %%S %'` matches the existing lowercase `%s` in the command and returns count > 0. The changeset marks itself as already done and **skips the update**.
- `addsplittingtranscoder_001_mysql` (`dbms="mysql"`) never runs on MariaDB.

Result: the `mp3 audio` step1 is never updated from `ffmpeg -i %s ...` to `ffmpeg %S -i %s ...`, and `%S` expands to nothing, so every track starts at position 0.

## Fix

Add a new changeset `addsplittingtranscoder_001_mariadb` targeting `dbms="mariadb"` that uses `LIKE BINARY` (case-sensitive) in the precondition — the same approach as the existing MySQL changeset.

## Test plan

- [ ] Fresh MariaDB install: after first start, `select step1 from transcoding where name='mp3 audio'` contains `%S`
- [ ] Existing MariaDB install: changeset applies on next startup, CUE tracks seek correctly thereafter
- [ ] H2 / HSQLDB / PostgreSQL installs: unaffected (changeset has `dbms="mariadb"` guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)