### PR TITLE
fix: stop indexing combined genre tags alongside split components

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/domain/Genres.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/Genres.java
@@ -45,24 +45,29 @@ public class Genres {
 
     public void incrementAlbumCount(String genreName, String separators) {
         String[] splitGenres = StringUtils.split(genreName, separators);
-        if (splitGenres.length > 1) { // otherwise it's the same genre as the original
+        if (splitGenres.length > 1) {
+            // Split genres: index each component only, not the combined string.
+            // The combined tag (e.g. "Dance;Edm;House") is an implementation detail
+            // of how tags are stored, not a genre in its own right.
             Stream.of(splitGenres)
                     .map(StringUtils::trim)
                     .filter(StringUtils::isNotBlank)
                     .forEach(s -> genres.computeIfAbsent(s, k -> new Genre(k)).incrementAlbumCount());
+        } else {
+            genres.computeIfAbsent(genreName, k -> new Genre(k)).incrementAlbumCount();
         }
-        genres.computeIfAbsent(genreName, k -> new Genre(k)).incrementAlbumCount();
     }
 
     public void incrementSongCount(String genreName, String separators) {
         String[] splitGenres = StringUtils.split(genreName, separators);
-        if (splitGenres.length > 1) { // otherwise it's the same genre as the original
+        if (splitGenres.length > 1) {
             Stream.of(splitGenres)
                     .map(StringUtils::trim)
                     .filter(StringUtils::isNotBlank)
                     .forEach(s -> genres.computeIfAbsent(s, k -> new Genre(k)).incrementSongCount());
+        } else {
+            genres.computeIfAbsent(genreName, k -> new Genre(k)).incrementSongCount();
         }
-        genres.computeIfAbsent(genreName, k -> new Genre(k)).incrementSongCount();
     }
 
     public List<Genre> getGenres() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -571,7 +571,11 @@ public class MediaFileService {
      * @return The updated genres.
      */
     @Transactional
-    public List<Genre> updateGenres(List <Genre> genres) {
+    public List<Genre> updateGenres(List<Genre> genres) {
+        // Replace the entire genre table so stale entries from previous scans
+        // (e.g. combined "Dance;Edm;House" after switching to split-tag mode)
+        // are not left behind with incorrect counts.
+        genreRepository.deleteAllInBatch();
         return genreRepository.saveAll(genres);
     }
 

--- a/airsonic-main/src/test/java/org/airsonic/player/domain/GenresTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/domain/GenresTest.java
@@ -1,0 +1,69 @@
+package org.airsonic.player.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GenresTest {
+
+    @Test
+    void testIncrementAlbumCountSingleGenre() {
+        Genres genres = new Genres();
+        genres.incrementAlbumCount("Rock", ";");
+        List<Genre> result = genres.getGenres();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getName()).isEqualTo("Rock");
+        assertThat(result.get(0).getAlbumCount()).isEqualTo(1);
+    }
+
+    @Test
+    void testIncrementAlbumCountSplitGenre() {
+        Genres genres = new Genres();
+        genres.incrementAlbumCount("Rock;Pop", ";");
+        Map<String, Genre> byName = genres.getGenres().stream()
+                .collect(Collectors.toMap(Genre::getName, g -> g));
+        // Only split components indexed, NOT combined "Rock;Pop"
+        assertThat(byName).containsKeys("Rock", "Pop");
+        assertThat(byName).doesNotContainKey("Rock;Pop");
+        assertThat(byName.get("Rock").getAlbumCount()).isEqualTo(1);
+        assertThat(byName.get("Pop").getAlbumCount()).isEqualTo(1);
+    }
+
+    @Test
+    void testIncrementSongCountSingleGenre() {
+        Genres genres = new Genres();
+        genres.incrementSongCount("Jazz", ";");
+        List<Genre> result = genres.getGenres();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getName()).isEqualTo("Jazz");
+        assertThat(result.get(0).getSongCount()).isEqualTo(1);
+    }
+
+    @Test
+    void testIncrementSongCountSplitGenre() {
+        Genres genres = new Genres();
+        genres.incrementSongCount("Jazz; Blues", ";");
+        Map<String, Genre> byName = genres.getGenres().stream()
+                .collect(Collectors.toMap(Genre::getName, g -> g));
+        // "Jazz" and "Blues" (trimmed), NOT "Jazz; Blues"
+        assertThat(byName).containsKeys("Jazz", "Blues");
+        assertThat(byName).doesNotContainKey("Jazz; Blues");
+        assertThat(byName.get("Jazz").getSongCount()).isEqualTo(1);
+        assertThat(byName.get("Blues").getSongCount()).isEqualTo(1);
+    }
+
+    @Test
+    void testBlankSplitComponentsIgnored() {
+        Genres genres = new Genres();
+        genres.incrementAlbumCount("Rock;;Pop", ";");
+        Map<String, Genre> byName = genres.getGenres().stream()
+                .collect(Collectors.toMap(Genre::getName, g -> g));
+        assertThat(byName).containsOnlyKeys("Rock", "Pop");
+        assertThat(byName.get("Rock").getAlbumCount()).isEqualTo(1);
+        assertThat(byName.get("Pop").getAlbumCount()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
## Problem

When **Genre separation characters** is configured, genre browsing shows three types of incorrect entries:

1. **Unsplit combined genres** — `Dance;Edm;House (3)` appearing alongside the individual `Dance`, `Edm`, `House` entries
2. **Empty genres (0 tracks)** — combined genres left over from a previous scan without separators configured, showing stale counts after a rescan
3. **Wrong browse counts** — `House (49)` shows only 15 tracks on browse because the listing count included tracks indexed under the combined string but the browse query used exact match (fixed separately in #850)

Closes #675

## Root cause

`Genres.incrementSongCount` (and `incrementAlbumCount`) always appended the original combined genre string unconditionally:

```java
if (splitGenres.length > 1) {
    // add "Dance", "Edm", "House"
}
genres.computeIfAbsent(genreName, ...).incrementSongCount(); // ALWAYS adds "Dance; Edm; House" too
```

Additionally, `MediaFileService.updateGenres` used `saveAll` (upsert), so stale combined entries from previous scans were never removed.

## Fix

1. **`Genres.java`** — add the combined string only when no splitting occurs (single component or no separators). When splitting does occur, only index the individual components.
2. **`MediaFileService.updateGenres`** — replace `saveAll` with `deleteAllInBatch` + `saveAll` so every scan produces a clean genre table that exactly reflects the current library and separator configuration.

## Test plan

- [ ] With `GenreSeparators=;` and a track tagged `Dance;Edm;House`, genre listing shows `Dance`, `Edm`, `House` but NOT `Dance;Edm;House`
- [ ] With `GenreSeparators=` (empty), genre listing shows `Dance;Edm;House` as a single entry
- [ ] After changing `GenreSeparators` from empty to `;` and rescanning, old combined entries are gone
- [ ] Song/album counts under split genres are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)