### PR TITLE
fix: auto-delete podcast channel when initial RSS feed fetch fails

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/PodcastManagementService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PodcastManagementService.java
@@ -149,7 +149,24 @@ public class PodcastManagementService {
     public PodcastChannel createChannel(String url) {
         PodcastChannel channel = podcastPersistenceService.createChannel(url);
         if (channel != null) {
-            refreshChannels(Arrays.asList(channel), true);
+            final int channelId = channel.getId();
+            podcastRefresher.refresh(channelId, true).whenComplete((result, x) -> {
+                if (x != null || Boolean.FALSE.equals(result)) {
+                    // Initial refresh failed: feed URL is invalid or unreachable.
+                    // Auto-delete so the user does not end up with a broken null-title channel.
+                    LOG.warn("Removing podcast channel {} because initial refresh failed", channelId);
+                    deleteChannel(channelId);
+                    return;
+                }
+                List<CompletableFuture<Void>> episodeFutures = podcastPersistenceService.getEpisodes(channelId)
+                    .stream()
+                    .filter(episode -> episode.getStatus() == PodcastStatus.NEW && episode.getUrl() != null)
+                    .map(ep -> podcastDownloadClient.downloadEpisode(ep.getId()))
+                    .collect(Collectors.toList());
+                CompletableFuture.allOf(episodeFutures.toArray(new CompletableFuture[0])).join();
+                podcastPersistenceService.setChannelCompleted(channel);
+                asyncWebSocketClient.send("/topic/podcasts/updated", channelId);
+            });
         }
         return channel;
     }
@@ -178,14 +195,20 @@ public class PodcastManagementService {
                     if (x != null) {
                         LOG.error("Failed to refresh channel {}", channel.getId(), x);
                         podcastPersistenceService.setChannelError(channel, x.getMessage());
+                        asyncWebSocketClient.send("/topic/podcasts/updated", channel.getId());
                         return;
-                    } else if (result && downloadEpisodes) {
+                    }
+                    if (!Boolean.TRUE.equals(result)) {
+                        // refresh() already called setChannelError; do not overwrite with COMPLETED
+                        return;
+                    }
+                    if (downloadEpisodes) {
                         List<CompletableFuture<Void>> episodeFutures = podcastPersistenceService.getEpisodes(channel.getId())
                             .stream()
                             .filter(episode -> episode.getStatus() == PodcastStatus.NEW && episode.getUrl() != null)
                             .map(ep -> podcastDownloadClient.downloadEpisode(ep.getId()))
                             .collect(Collectors.toList());
-                        CompletableFuture.allOf(episodeFutures.toArray(new CompletableFuture[episodeFutures.size()])).join();
+                        CompletableFuture.allOf(episodeFutures.toArray(new CompletableFuture[0])).join();
                     }
                     podcastPersistenceService.setChannelCompleted(channel);
                     asyncWebSocketClient.send("/topic/podcasts/updated", channel.getId());

--- a/airsonic-main/src/test/java/org/airsonic/player/service/PodcastManagementServiceTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/PodcastManagementServiceTestCase.java
@@ -25,6 +25,8 @@ import org.airsonic.player.domain.MusicFolder;
 import org.airsonic.player.domain.PodcastChannel;
 import org.airsonic.player.domain.PodcastChannelRule;
 import org.airsonic.player.domain.PodcastEpisode;
+import org.airsonic.player.service.podcast.PodcastDownloadClient;
+import org.airsonic.player.service.podcast.PodcastRefresher;
 import org.airsonic.player.service.websocket.AsyncWebSocketClient;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -43,8 +45,12 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -62,6 +68,10 @@ public class PodcastManagementServiceTestCase {
     private AsyncWebSocketClient asyncWebSocketClient;
     @Mock
     private PodcastPersistenceService podcastPersistenceService;
+    @Mock
+    private PodcastRefresher podcastRefresher;
+    @Mock
+    private PodcastDownloadClient podcastDownloadClient;
 
     @InjectMocks
     @Spy
@@ -177,6 +187,47 @@ public class PodcastManagementServiceTestCase {
         verify(taskService).unscheduleTask(eq("podcast-channel-refresh-" + id));
     }
 
+    @Test
+    void testCreateChannelDeletesOnRefreshReturnFalse() {
+        when(podcastPersistenceService.createChannel(anyString())).thenReturn(mockedChannel);
+        when(mockedChannel.getId()).thenReturn(1);
+        when(podcastRefresher.refresh(1, true)).thenReturn(CompletableFuture.completedFuture(false));
+        when(podcastPersistenceService.deleteChannel(1)).thenReturn(true);
+
+        podcastManagementService.createChannel("http://example.com/feed");
+
+        verify(podcastPersistenceService).deleteChannel(1);
+        verify(asyncWebSocketClient).send("/topic/podcasts/deleted", 1);
+    }
+
+    @Test
+    void testCreateChannelDeletesOnRefreshException() {
+        when(podcastPersistenceService.createChannel(anyString())).thenReturn(mockedChannel);
+        when(mockedChannel.getId()).thenReturn(1);
+        CompletableFuture<Boolean> failed = new CompletableFuture<>();
+        failed.completeExceptionally(new RuntimeException("feed error"));
+        when(podcastRefresher.refresh(1, true)).thenReturn(failed);
+        when(podcastPersistenceService.deleteChannel(1)).thenReturn(true);
+
+        podcastManagementService.createChannel("http://example.com/feed");
+
+        verify(podcastPersistenceService).deleteChannel(1);
+        verify(asyncWebSocketClient).send("/topic/podcasts/deleted", 1);
+    }
+
+    @Test
+    void testCreateChannelSuccessDoesNotDelete() {
+        when(podcastPersistenceService.createChannel(anyString())).thenReturn(mockedChannel);
+        when(mockedChannel.getId()).thenReturn(1);
+        when(podcastRefresher.refresh(1, true)).thenReturn(CompletableFuture.completedFuture(true));
+        when(podcastPersistenceService.getEpisodes(1)).thenReturn(Collections.emptyList());
+
+        podcastManagementService.createChannel("http://example.com/feed");
+
+        verify(podcastPersistenceService, never()).deleteChannel(anyInt());
+        verify(asyncWebSocketClient, never()).send(eq("/topic/podcasts/deleted"), anyInt());
+        verify(asyncWebSocketClient).send("/topic/podcasts/updated", 1);
+    }
 
     @Test
     void testScheduleDefaultWithIntervalConfigShouldSchedule() {


### PR DESCRIPTION
## Summary

Fixes #639

When a user adds an invalid or unreachable podcast URL, the channel is created in the database and an async feed refresh is fired. If the refresh fails the channel persists with a null title and ERROR status, polluting the podcast list with a broken entry the user cannot easily distinguish from a valid one.

**Changes:**

- `createChannel()` now chains directly on the `refresh()` future and calls `deleteChannel()` if the initial fetch fails (result=false or exception). The WebSocket `/topic/podcasts/deleted` notification is sent so the UI updates immediately.
- `refreshChannels()` fixed: when `refresh()` returns `false` it has already called `setChannelError()` internally. The subsequent unconditional `setChannelCompleted()` call was overwriting the ERROR status with COMPLETED. Now guarded with `Boolean.TRUE.equals(result)` so ERROR is preserved for periodic refreshes too.

## Test plan

- [ ] Add a podcast channel with a valid RSS URL -- channel appears and episodes load normally
- [ ] Add a podcast channel with an invalid/unreachable URL (e.g. `http://localhost:9999/nope`) -- channel disappears from the UI after the async refresh completes (no zombie entry left)
- [ ] Trigger a periodic refresh on an existing channel whose feed goes down -- channel stays in the list with ERROR status (not silently flipped to COMPLETED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)