### PR TITLE
fix: require meaningful bytes streamed before counting a play

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
@@ -219,11 +219,16 @@ public class StreamController {
             statusService.addActiveLocalPlay(
                     new PlayStatus(status.getId(), mediaFile, player, status.getMillisSinceLastUpdate()));
         };
-        BiConsumer<Integer, MediaFile> fileEndListener = (readCount, mediaFile) -> {
-            if (readCount != null && readCount > 0 && player.getTechnology() != PlayerTechnology.WEB) {
-                // Increment play count if the file was actually played
-                // WEB player increments play count on the client side
-                mediaFileService.incrementPlayCount(player, mediaFile);
+        BiConsumer<Long, MediaFile> fileEndListener = (bytesStreamed, mediaFile) -> {
+            if (bytesStreamed != null && player.getTechnology() != PlayerTechnology.WEB) {
+                // Require at least 10% of the estimated file size to count as a play.
+                // This prevents external players that probe stream URLs for metadata
+                // from inflating play counts on every file access.
+                // WEB player increments play count on the client side.
+                long estimatedBytes = estimateFileBytes(mediaFile);
+                if (bytesStreamed >= estimatedBytes / 10) {
+                    mediaFileService.incrementPlayCount(player, mediaFile);
+                }
             }
             scrobble(mediaFile, player, true);
             statusService.removeActiveLocalPlay(
@@ -289,6 +294,17 @@ public class StreamController {
     @ExceptionHandler(AsyncRequestNotUsableException.class)
     public void handleAsyncRequestNotUsableException(AsyncRequestNotUsableException e) {
         LOG.info("Client Aborted");
+    }
+
+    private long estimateFileBytes(MediaFile mediaFile) {
+        Double duration = mediaFile.getDuration();
+        Integer bitRate = mediaFile.getBitRate();
+        if (duration != null && duration > 0 && bitRate != null && bitRate > 0) {
+            return (long) (duration * bitRate * 1000L / 8);
+        }
+        // Unknown duration/bitrate: use a conservative 256 KB floor so any real
+        // playback attempt passes while a brief metadata probe does not.
+        return 256L * 1024;
     }
 
     private void scrobble(MediaFile mediaFile, Player player, boolean submission) {

--- a/airsonic-main/src/main/java/org/airsonic/player/io/PlayQueueInputStream.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/io/PlayQueueInputStream.java
@@ -12,14 +12,14 @@ import java.util.function.Function;
 public class PlayQueueInputStream extends InputStream {
     private final PlayQueue queue;
     private final Consumer<MediaFile> fileStartListener;
-    private final BiConsumer<Integer, MediaFile> fileEndListener;
+    private final BiConsumer<Long, MediaFile> fileEndListener;
     private final Function<MediaFile, InputStream> streamGenerator;
     private InputStream currentStream;
     private MediaFile currentFile;
-    private Integer readCount = 0;
+    private long bytesRead = 0;
 
     public PlayQueueInputStream(PlayQueue queue, Consumer<MediaFile> fileStartListener,
-            BiConsumer<Integer, MediaFile> fileEndListener, Function<MediaFile, InputStream> streamGenerator) {
+            BiConsumer<Long, MediaFile> fileEndListener, Function<MediaFile, InputStream> streamGenerator) {
         this.queue = queue;
         this.fileStartListener = fileStartListener;
         this.fileEndListener = fileEndListener;
@@ -54,6 +54,7 @@ public class PlayQueueInputStream extends InputStream {
             return read(b, off, len);
         }
 
+        bytesRead += n;
         return n;
     }
 
@@ -73,8 +74,6 @@ public class PlayQueueInputStream extends InputStream {
             currentFile = file;
             fileStartListener.accept(currentFile);
             currentStream = streamGenerator.apply(currentFile);
-        } else {
-            readCount++;
         }
     }
 
@@ -84,10 +83,10 @@ public class PlayQueueInputStream extends InputStream {
             currentStream = null;
         }
         if (currentFile != null) {
-            fileEndListener.accept(readCount, currentFile);
+            fileEndListener.accept(bytesRead, currentFile);
             currentFile = null;
         }
-        readCount = 0;
+        bytesRead = 0;
     }
 
     @Override

--- a/airsonic-main/src/test/java/org/airsonic/player/io/PlayQueueInputStreamTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/io/PlayQueueInputStreamTest.java
@@ -1,0 +1,129 @@
+package org.airsonic.player.io;
+
+import org.airsonic.player.domain.MediaFile;
+import org.airsonic.player.domain.PlayQueue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class PlayQueueInputStreamTest {
+
+    @Mock
+    private PlayQueue queue;
+
+    @Mock
+    private MediaFile file1;
+
+    @Mock
+    private MediaFile file2;
+
+    @Test
+    void testBytesAccumulatedAcrossReads() throws IOException {
+        byte[] data = new byte[100];
+        for (int i = 0; i < data.length; i++) data[i] = (byte) i;
+
+        when(queue.getCurrentFile()).thenReturn(file1);
+        when(queue.getStatus()).thenReturn(PlayQueue.Status.PLAYING);
+
+        AtomicLong capturedBytes = new AtomicLong(-1);
+
+        try (PlayQueueInputStream pqis = new PlayQueueInputStream(
+                queue,
+                f -> {},
+                (bytes, f) -> capturedBytes.set(bytes),
+                f -> new ByteArrayInputStream(data))) {
+
+            byte[] buf = new byte[10];
+            int total = 0;
+            int n;
+            // exhaust the stream then trigger closeStream via null file
+            while ((n = pqis.read(buf)) > 0) {
+                total += n;
+                if (total >= 100) break;
+            }
+            when(queue.getCurrentFile()).thenReturn(null);
+            pqis.read(buf); // triggers closeStream via prepare()
+        }
+
+        assertThat(capturedBytes.get()).isEqualTo(100L);
+    }
+
+    @Test
+    void testFileEndListenerReceivesBytesNotCallCount() throws IOException {
+        byte[] data = new byte[50];
+
+        when(queue.getCurrentFile()).thenReturn(file1);
+        when(queue.getStatus()).thenReturn(PlayQueue.Status.PLAYING);
+
+        AtomicLong capturedBytes = new AtomicLong(-1);
+
+        try (PlayQueueInputStream pqis = new PlayQueueInputStream(
+                queue,
+                f -> {},
+                (bytes, f) -> capturedBytes.set(bytes),
+                f -> new ByteArrayInputStream(data))) {
+
+            // 10 reads of 5 bytes each
+            byte[] buf = new byte[5];
+            for (int i = 0; i < 10; i++) {
+                pqis.read(buf);
+            }
+            when(queue.getCurrentFile()).thenReturn(null);
+            pqis.read(buf); // flush via closeStream
+        }
+
+        // Must be 50 (bytes), not 10 (call count)
+        assertThat(capturedBytes.get()).isEqualTo(50L);
+    }
+
+    @Test
+    void testBytesResetBetweenFiles() throws IOException {
+        byte[] data1 = new byte[30];
+        byte[] data2 = new byte[70];
+
+        List<Long> capturedBytes = new ArrayList<>();
+
+        // First call returns file1, subsequent calls after next() return file2
+        when(queue.getCurrentFile()).thenReturn(file1);
+        when(queue.getStatus()).thenReturn(PlayQueue.Status.PLAYING);
+
+        PlayQueueInputStream pqis = new PlayQueueInputStream(
+                queue,
+                f -> {},
+                (bytes, f) -> capturedBytes.add(bytes),
+                f -> {
+                    if (f == file1) return new ByteArrayInputStream(data1);
+                    return new ByteArrayInputStream(data2);
+                });
+
+        // Read file1 fully -- when ByteArrayInputStream returns -1, PlayQueueInputStream
+        // calls queue.next() then closeStream()
+        when(queue.getCurrentFile())
+                .thenReturn(file1)   // prepare() for first read
+                .thenReturn(file1)   // getStatus() calls inside read
+                .thenReturn(file2);  // after next() returns file2
+
+        byte[] buf = new byte[100];
+        // First read gets file1's 30 bytes
+        pqis.read(buf, 0, 100);
+        // closeStream was called for file1 (ByteArrayInputStream exhausted), file2 starts
+        // close the stream to flush file2's listener
+        when(queue.getCurrentFile()).thenReturn(null);
+        pqis.close();
+
+        assertThat(capturedBytes).hasSize(2);
+        assertThat(capturedBytes.get(0)).isEqualTo(30L); // file1
+        assertThat(capturedBytes.get(1)).isEqualTo(70L); // file2
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #610

External players (e.g. Foobar2000) probe stream URLs to read audio metadata when indexing a playlist m3u. Each probe opens the stream, reads a small buffer, then closes — which was counted as a play because the only guard was `readCount > 0` (literally any two `read()` calls).

**Root cause:** `PlayQueueInputStream` tracked the number of `read()` calls per file, not bytes delivered. `StreamController.fileEndListener` checked `readCount > 0`, so even a brief metadata probe that made 2-3 read calls counted as a full play.

**Fix:**
- `PlayQueueInputStream`: replace `readCount` (call counter) with `bytesRead` (byte accumulator). `fileEndListener` signature changes from `BiConsumer<Integer, MediaFile>` to `BiConsumer<Long, MediaFile>`.
- `StreamController`: require at least **10% of the estimated file size** to be streamed before incrementing play count. Estimated size = `duration × bitrate`. Falls back to a 256 KB floor when metadata is absent.

A 3-minute 128 kbps MP3 (~2.8 MB) requires ~280 KB streamed. A typical metadata probe reads ≤ 64 KB. Real playback easily clears the threshold; probes do not.

Note: this is complementary to but independent of #788 (moving play count fully to the scrobble endpoint). This patch addresses the immediate user-facing regression with minimal scope.

## Test plan

- [ ] Add a playlist to an external player (Foobar2000, VLC, etc.) and let it index/probe the m3u — play counts should not increment
- [ ] Actually play a track to completion in an external player — play count increments once
- [ ] Skip rapidly through tracks in external player — play counts do not inflate
- [ ] Internal web player play counts are unaffected (still handled client-side, `PlayerTechnology.WEB` excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)