### PR TITLE
fix: replace busy-wait in download pipe setup with CountDownLatch timeout

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
@@ -61,6 +61,8 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -255,11 +257,12 @@ public class DownloadController {
             // zip to out
             BiConsumer<InputStream, TransferStatus> poutInit = (input, status) -> {
                 PipedInputStream pin = (PipedInputStream) input;
+                CountDownLatch connected = new CountDownLatch(1);
 
-                // start a new thread to feed data in
-                new Thread(() -> {
+                Thread dataThread = new Thread(() -> {
                     try (PipedOutputStream pout = new PipedOutputStream(pin);
                             ZipOutputStream zout = new ZipOutputStream(pout)) {
+                        connected.countDown(); // pipe is now connected, unblock caller
                         zout.setMethod(ZipOutputStream.STORED); // No compression.
                         pathsToZip.stream().forEach(LambdaUtils.uncheckConsumer(f -> {
                             status.setExternalFile(f.getLeft());
@@ -280,13 +283,25 @@ public class DownloadController {
                             zout.closeEntry();
                         }));
                     } catch (Exception e1) {
+                        connected.countDown(); // unblock caller even on failure
                         LOG.debug("Error with output to zip", e1);
                     }
-                }, "DownloadControllerDatafeed").start();
+                }, "DownloadControllerDatafeed");
 
-                // wait for src data thread to connect
-                while (pin.source == null) {
-                    // sit and wait and ponder life
+                try {
+                    dataThread.start();
+                } catch (Exception e) {
+                    throw new RuntimeException("Failed to start download data thread", e);
+                }
+
+                try {
+                    if (!connected.await(30, TimeUnit.SECONDS)) {
+                        dataThread.interrupt();
+                        throw new RuntimeException("Timed out waiting for download data thread to connect");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Interrupted waiting for download data thread", e);
                 }
             };
 

--- a/airsonic-main/src/main/java/org/airsonic/player/io/PipeStreams.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/io/PipeStreams.java
@@ -106,7 +106,7 @@ public class PipeStreams {
         @Override
         public void close() throws IOException {
             if (source == null) {
-                throw new IOException("Unconnected pipe");
+                return;
             }
 
             synchronized (buffer) {

--- a/airsonic-main/src/test/java/org/airsonic/player/io/PipeStreamsTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/io/PipeStreamsTest.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class PipeStreamsTest {
@@ -143,5 +144,14 @@ public class PipeStreamsTest {
         }
 
         assertThat(eventSet).containsOnly("inputStreamOpened", "statusClosed");
+    }
+
+    @Test
+    public void testCloseUnconnectedPipedInputStreamDoesNotThrow() throws IOException {
+        // PipedInputStream with no connected source must close silently.
+        // Previously threw IOException("Unconnected pipe"), which prevented
+        // MonitoredInputStream.close() from running statusCloser, leaking TransferStatus.
+        PipedInputStream pin = new PipedInputStream(null, 16);
+        assertThatNoException().isThrownBy(pin::close);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #811

Downloads failed permanently after a few albums and only a server restart recovered them.

**Root cause:** The zip download path spawns a data feed thread that connects a `PipedOutputStream` to the `PipedInputStream`. The main request thread (Tomcat worker) busy-waited for the connection with `while (pin.source == null) { /* sit and wait and ponder life */ }`. If the JVM could not create a new thread (thread limit exhausted by leaked threads from previous failed downloads), `Thread.start()` threw an uncaught exception and the busy-wait spun forever — permanently consuming a Tomcat worker thread. After enough accumulated stuck workers, no new HTTP requests could be handled until restart.

**Three fixes:**

1. **`DownloadController`**: replace the infinite busy-wait with `CountDownLatch.await()` with a 30-second timeout. The data thread calls `countDown()` once `PipedOutputStream` is connected (or on any exception). `Thread.start()` is now wrapped so failures propagate immediately as a 500 error rather than hanging the worker thread indefinitely.

2. **`DownloadController`**: data thread calls `countDown()` in its `catch` block so the caller always unblocks, even when pipe construction fails.

3. **`PipeStreams.PipedInputStream.close()`**: return silently when `source == null` instead of throwing `IOException("Unconnected pipe")`. Previously, if `close()` was called before the pipe was connected (e.g. client disconnect between response header write and body streaming), `MonitoredInputStream.close()` threw before `statusCloser` ran — leaking `TransferStatus` entries and leaving the data thread permanently blocked waiting for a reader that would never come.

## Test plan

- [ ] Download a single track — works normally
- [ ] Download a large album (10+ tracks) — completes successfully, "Transferred X bytes" logged
- [ ] Download several albums back-to-back — each succeeds; no server freeze
- [ ] Abort a download mid-transfer (close browser tab) — subsequent downloads still work; "Transferred X bytes" logged for the aborted one
- [ ] Server thread count does not grow unbounded across many downloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)