### PR TITLE
fix: replace defunct chartlyrics.com with local lyrics lookup

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/LyricsWSController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/LyricsWSController.java
@@ -19,42 +19,23 @@
  */
 package org.airsonic.player.ajax;
 
+import org.airsonic.player.domain.Lyrics;
 import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.service.LyricsService;
 import org.airsonic.player.service.MediaFileService;
 import org.airsonic.player.service.SecurityService;
-import org.airsonic.player.util.StringUtil;
-import org.apache.commons.lang.StringUtils;
-import org.apache.http.client.HttpResponseException;
-import org.apache.http.client.ResponseHandler;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.conn.ConnectTimeoutException;
-import org.apache.http.impl.client.BasicResponseHandler;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.jdom2.Namespace;
-import org.jdom2.input.SAXBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.stereotype.Controller;
 
-import java.io.IOException;
-import java.io.StringReader;
-import java.net.SocketException;
 import java.security.Principal;
 
-import static org.airsonic.player.util.XMLUtil.createSAXBuilder;
-
 /**
- * Provides services for retrieving song lyrics from chartlyrics.com.
- * <p/>
- * See http://www.chartlyrics.com/api.aspx for details.
- *
+ * Provides lyrics for a song, sourced from local LRC files or the database.
+ * The previous implementation fetched from chartlyrics.com, which has been
+ * defunct for several years. Searches now use local sources only.
  */
 @Controller
 @MessageMapping("/lyrics")
@@ -63,9 +44,7 @@ public class LyricsWSController {
     private static final Logger LOG = LoggerFactory.getLogger(LyricsWSController.class);
 
     private final LyricsService lyricsService;
-
     private final SecurityService securityService;
-
     private final MediaFileService mediaFileService;
 
     public LyricsWSController(
@@ -77,76 +56,42 @@ public class LyricsWSController {
         this.mediaFileService = mediaFileService;
     }
 
-
     /**
-     * Returns lyrics for the given song and artist.
-     *
-     * @return The lyrics, never <code>null</code> .
+     * Returns lyrics for the given song. Checks the local database and any
+     * sidecar LRC file. If lyrics are found they are persisted (if not already)
+     * and the client is asked to reload the page. If none are found the client
+     * receives an empty status so it can show "no lyrics found" instead of the
+     * misleading "try again later" message that was produced by the defunct
+     * chartlyrics.com integration.
      */
     @MessageMapping("/get")
     @SendToUser(broadcast = false)
     public LyricsStatus getLyrics(Principal user, LyricsGetRequest req) {
 
-        String artist = req.getArtist();
-        String song = req.getSong();
-
         LyricsStatus status = new LyricsStatus();
+
+        if (req.getId() == null) {
+            return status;
+        }
+
+        MediaFile mediaFile = mediaFileService.getMediaFile(req.getId());
+        if (mediaFile == null || !securityService.isFolderAccessAllowed(mediaFile, user.getName())) {
+            return status;
+        }
+
         try {
-
-            artist = StringUtil.urlEncode(artist);
-            song = StringUtil.urlEncode(song);
-
-            String url = "http://api.chartlyrics.com/apiv1.asmx/SearchLyricDirect?artist=" + artist + "&song=" + song;
-            String xml = executeGetRequest(url);
-            String lyrics = parseSearchResult(xml);
-
-            if (lyrics != null && req.getId() != null) {
-                MediaFile mediaFile = mediaFileService.getMediaFile(req.getId());
-                if (mediaFile != null && securityService.isFolderAccessAllowed(mediaFile, user.getName())) {
-                    boolean persisted = lyricsService.saveLyricsForMediaFile(mediaFile, lyrics, "chartlyrics.com");
-                    LOG.info("Persisted lyrics for song '{}' by '{}': {}", song, artist, persisted);
-                    status.setPersisted(persisted);
-                }
+            Lyrics lyrics = lyricsService.getLyricsFromMediaFile(mediaFile);
+            if (lyrics != null) {
+                // Lyrics were found (possibly just loaded from a sidecar .lrc file into the
+                // database for the first time). Signal the client to reload so the new data
+                // is displayed via the normal server-side render path.
+                status.setPersisted(true);
             }
-        } catch (HttpResponseException x) {
-            LOG.warn("Failed to get lyrics for song '{}'. Request failed: {}", song, x.toString());
-            if (x.getStatusCode() == 503) {
-                status.setTryLater(true);
-            }
-        } catch (SocketException | ConnectTimeoutException x) {
-            LOG.warn("Failed to get lyrics for song '{}': {}", song, x.toString());
-            status.setTryLater(true);
         } catch (Exception x) {
-            LOG.warn("Failed to get lyrics for song '" + song + "'.", x);
+            LOG.warn("Failed to retrieve lyrics for media file {}", req.getId(), x);
         }
+
         return status;
-    }
-
-
-
-    private String parseSearchResult(String xml) throws Exception {
-        SAXBuilder builder = createSAXBuilder();
-        Document document = builder.build(new StringReader(xml));
-
-        Element root = document.getRootElement();
-        Namespace ns = root.getNamespace();
-
-        String lyric = StringUtils.trimToNull(root.getChildText("Lyric", ns));
-
-        return lyric;
-    }
-
-    private String executeGetRequest(String url) throws IOException {
-        RequestConfig requestConfig = RequestConfig.custom()
-                .setConnectTimeout(15000)
-                .setSocketTimeout(15000)
-                .build();
-        HttpGet method = new HttpGet(url);
-        method.setConfig(requestConfig);
-        try (CloseableHttpClient client = HttpClients.createDefault()) {
-            ResponseHandler<String> responseHandler = new BasicResponseHandler();
-            return client.execute(method, responseHandler);
-        }
     }
 
     public static class LyricsGetRequest {

--- a/airsonic-main/src/test/java/org/airsonic/player/ajax/LyricsWSControllerTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/ajax/LyricsWSControllerTest.java
@@ -1,0 +1,102 @@
+package org.airsonic.player.ajax;
+
+import org.airsonic.player.domain.Lyrics;
+import org.airsonic.player.domain.MediaFile;
+import org.airsonic.player.service.LyricsService;
+import org.airsonic.player.service.MediaFileService;
+import org.airsonic.player.service.SecurityService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LyricsWSControllerTest {
+
+    @Mock
+    private LyricsService lyricsService;
+    @Mock
+    private SecurityService securityService;
+    @Mock
+    private MediaFileService mediaFileService;
+    @Mock
+    private Principal user;
+
+    @InjectMocks
+    private LyricsWSController controller;
+
+    private MediaFile mediaFile;
+
+    @BeforeEach
+    void setUp() {
+        mediaFile = new MediaFile();
+        mediaFile.setId(42);
+        when(user.getName()).thenReturn("alice");
+    }
+
+    @Test
+    void nullId_returnsEmptyStatus() {
+        LyricsWSController.LyricsGetRequest req = new LyricsWSController.LyricsGetRequest(null, null, null);
+        LyricsStatus status = controller.getLyrics(user, req);
+        assertFalse(status.isPersisted());
+        verifyNoInteractions(mediaFileService, lyricsService, securityService);
+    }
+
+    @Test
+    void unknownMediaFile_returnsEmptyStatus() {
+        when(mediaFileService.getMediaFile(99)).thenReturn(null);
+        LyricsWSController.LyricsGetRequest req = new LyricsWSController.LyricsGetRequest(null, null, 99);
+        LyricsStatus status = controller.getLyrics(user, req);
+        assertFalse(status.isPersisted());
+        verifyNoInteractions(lyricsService);
+    }
+
+    @Test
+    void accessDenied_returnsEmptyStatus() {
+        when(mediaFileService.getMediaFile(42)).thenReturn(mediaFile);
+        when(securityService.isFolderAccessAllowed(mediaFile, "alice")).thenReturn(false);
+        LyricsWSController.LyricsGetRequest req = new LyricsWSController.LyricsGetRequest(null, null, 42);
+        LyricsStatus status = controller.getLyrics(user, req);
+        assertFalse(status.isPersisted());
+        verifyNoInteractions(lyricsService);
+    }
+
+    @Test
+    void lyricsFound_returnsPersistedTrue() throws Exception {
+        Lyrics lyrics = new Lyrics();
+        when(mediaFileService.getMediaFile(42)).thenReturn(mediaFile);
+        when(securityService.isFolderAccessAllowed(mediaFile, "alice")).thenReturn(true);
+        when(lyricsService.getLyricsFromMediaFile(mediaFile)).thenReturn(lyrics);
+        LyricsWSController.LyricsGetRequest req = new LyricsWSController.LyricsGetRequest(null, null, 42);
+        LyricsStatus status = controller.getLyrics(user, req);
+        assertTrue(status.isPersisted());
+    }
+
+    @Test
+    void noLyricsFound_returnsPersistedFalse() throws Exception {
+        when(mediaFileService.getMediaFile(42)).thenReturn(mediaFile);
+        when(securityService.isFolderAccessAllowed(mediaFile, "alice")).thenReturn(true);
+        when(lyricsService.getLyricsFromMediaFile(mediaFile)).thenReturn(null);
+        LyricsWSController.LyricsGetRequest req = new LyricsWSController.LyricsGetRequest(null, null, 42);
+        LyricsStatus status = controller.getLyrics(user, req);
+        assertFalse(status.isPersisted());
+    }
+
+    @Test
+    void serviceException_returnsEmptyStatus() throws Exception {
+        when(mediaFileService.getMediaFile(42)).thenReturn(mediaFile);
+        when(securityService.isFolderAccessAllowed(mediaFile, "alice")).thenReturn(true);
+        when(lyricsService.getLyricsFromMediaFile(mediaFile)).thenThrow(new RuntimeException("db error"));
+        LyricsWSController.LyricsGetRequest req = new LyricsWSController.LyricsGetRequest(null, null, 42);
+        LyricsStatus status = controller.getLyrics(user, req);
+        assertFalse(status.isPersisted());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #820

The lyrics search WebSocket endpoint (`LyricsWSController`) was calling `http://api.chartlyrics.com/apiv1.asmx/SearchLyricDirect`, which has been offline for years. Every search returned HTTP 503, which the client translated to the message:

> Sorry, the lyrics search engine allows just one search every 20 seconds. Try again later.

This message was never going to succeed — the API is permanently gone.

**Fix:** Remove the dead HTTP call entirely. Replace with a call to `LyricsService.getLyricsFromMediaFile()`, which already implements local lookup via the database and sidecar `.lrc` files (added in recent lyrics refactor). Behaviour:

- Lyrics found locally (DB or `.lrc`) → `persisted=true` → client reloads page, which renders lyrics via the normal server-side path
- No local lyrics → empty `LyricsStatus` → client shows "no lyrics found" instead of the misleading rate-limit error

The defunct Apache HttpClient imports and the XML parsing helper are also removed from this class.

## Test plan

- [ ] Song with a sidecar `.lrc` file: click Lyrics → page loads and shows lyrics (no error)
- [ ] Song with lyrics already in DB: click Lyrics → page loads and shows lyrics
- [ ] Song with no lyrics anywhere: click Search → shows "no lyrics found" (not "try again later")
- [ ] Non-existent or access-denied media file ID: returns empty status, no error logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)