### PR TITLE
fix: allow admin to view and manage any user's credentials

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/CredentialsManagementController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/CredentialsManagementController.java
@@ -9,6 +9,7 @@ import org.airsonic.player.domain.UserCredential.App;
 import org.airsonic.player.security.PasswordEncoderConfig;
 import org.airsonic.player.service.SecurityService;
 import org.airsonic.player.service.SettingsService;
+import org.airsonic.player.service.UserService;
 import org.airsonic.player.validator.CredentialsManagementValidators.CredentialCreateChecks;
 import org.airsonic.player.validator.CredentialsManagementValidators.CredentialUpdateChecks;
 import org.apache.commons.beanutils.BeanMap;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import jakarta.validation.groups.Default;
@@ -31,6 +33,7 @@ import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toMap;
@@ -45,6 +48,9 @@ public class CredentialsManagementController {
     @Autowired
     private SettingsService settingsService;
 
+    @Autowired
+    private UserService userService;
+
     private static final Map<String, String> ENCODER_ALIASES = ImmutableMap.of("noop", "plaintext", "legacynoop",
             "legacyplaintext (deprecated)", "legacyhex", "legacyhex (deprecated)");
 
@@ -54,8 +60,20 @@ public class CredentialsManagementController {
     }
 
     @ModelAttribute
-    protected void displayForm(Authentication user, ModelMap map) {
-        List<CredentialsCommand> creds = securityService.getCredentials(user.getName(), App.values())
+    protected void displayForm(Authentication user, ModelMap map,
+            @RequestParam(required = false) String username) {
+        User userInDb = securityService.getUserByName(user.getName());
+
+        // Admins may view/manage credentials for any user via ?username=X
+        String targetUsername = user.getName();
+        if (userInDb.isAdminRole() && username != null && !username.isBlank()) {
+            User targetUser = securityService.getUserByName(username);
+            if (targetUser != null) {
+                targetUsername = username;
+            }
+        }
+
+        List<CredentialsCommand> creds = securityService.getCredentials(targetUsername, App.values())
                 .parallelStream()
                 .map(CredentialsCommand::fromUserCredential)
                 .map(c -> {
@@ -78,8 +96,6 @@ public class CredentialsManagementController {
                 .sorted(Comparator.comparing(CredentialsCommand::getCreated))
                 .collect(Collectors.toList());
 
-        User userInDb = securityService.getUserByName(user.getName());
-
         // for updates/deletes/read
         map.addAttribute("command", new CredentialsManagementCommand(creds));
         // for new creds
@@ -95,55 +111,78 @@ public class CredentialsManagementController {
         map.addAttribute("preferredEncoderNonDecodableAllowed", securityService.getPreferredPasswordEncoder(true));
         map.addAttribute("preferredEncoderDecodableOnly", securityService.getPreferredPasswordEncoder(false));
 
-        map.addAttribute("ldapAuthEnabledForUser", userInDb.isLdapAuthenticated());
+        map.addAttribute("ldapAuthEnabledForUser", securityService.getUserByName(targetUsername).isLdapAuthenticated());
         map.addAttribute("adminRole", userInDb.isAdminRole());
+        map.addAttribute("targetUsername", targetUsername);
 
         // admin restricted, installation-wide settings
-        if (userInDb.isAdminRole() && !map.containsAttribute("adminControls")) {
-            map.addAttribute("adminControls",
-                    new AdminControls(
-                            securityService.checkLegacyCredsPresent(),
-                            securityService.checkOpenCredsPresent(),
-                            securityService.checkDefaultAdminCredsPresent(),
-                            settingsService.getJWTKey(),
-                            settingsService.getEncryptionPassword(),
-                            settingsService.getEncryptionSalt(),
-                            settingsService.getNonDecodablePasswordEncoder(),
-                            settingsService.getDecodablePasswordEncoder(),
-                            settingsService.getPreferNonDecodablePasswords()
-                            ));
+        if (userInDb.isAdminRole()) {
+            map.addAttribute("allUsernames",
+                    userService.getAllUsers().stream().map(User::getUsername).sorted().collect(Collectors.toList()));
+            if (!map.containsAttribute("adminControls")) {
+                map.addAttribute("adminControls",
+                        new AdminControls(
+                                securityService.checkLegacyCredsPresent(),
+                                securityService.checkOpenCredsPresent(),
+                                securityService.checkDefaultAdminCredsPresent(),
+                                settingsService.getJWTKey(),
+                                settingsService.getEncryptionPassword(),
+                                settingsService.getEncryptionSalt(),
+                                settingsService.getNonDecodablePasswordEncoder(),
+                                settingsService.getDecodablePasswordEncoder(),
+                                settingsService.getPreferNonDecodablePasswords()
+                                ));
+            }
         }
     }
 
     @PostMapping
-    protected String createNewCreds(Principal user,
+    protected String createNewCreds(Authentication user,
             @ModelAttribute("newCreds") @Validated(value = { Default.class, CredentialCreateChecks.class }) CredentialsCommand cc,
-            BindingResult br, RedirectAttributes redirectAttributes, ModelMap map) {
+            BindingResult br, RedirectAttributes redirectAttributes, ModelMap map,
+            @RequestParam(required = false) String targetUsername) {
         if (br.hasErrors()) {
             map.addAttribute("open_CreateCredsDialog", true);
             return "credentialsSettings";
         }
 
-        boolean success = securityService.createCredential(user.getName(), cc, "Created by user");
+        String credOwner = resolveTargetUsername(user, targetUsername);
+        boolean success = securityService.createCredential(credOwner, cc, "Created by user");
 
         redirectAttributes.addFlashAttribute("settings_toast", success);
 
-        return "redirect:credentialsSettings.view";
+        return "redirect:credentialsSettings.view" + (credOwner.equals(user.getName()) ? "" : "?username=" + credOwner);
     }
 
     @PostMapping("update")
-    protected String updateCreds(Principal user,
+    protected String updateCreds(Authentication user,
             @ModelAttribute("command") @Validated(value = { Default.class, CredentialUpdateChecks.class }) CredentialsManagementCommand cmc,
-            BindingResult br, RedirectAttributes redirectAttributes) {
+            BindingResult br, RedirectAttributes redirectAttributes,
+            @RequestParam(required = false) String targetUsername) {
         if (br.hasErrors()) {
             return "credentialsSettings";
         }
 
-        boolean result = securityService.updateCredentials(user.getName(), cmc, "User updated", false);
+        String credOwner = resolveTargetUsername(user, targetUsername);
+        boolean result = securityService.updateCredentials(credOwner, cmc, "User updated", false);
 
         redirectAttributes.addFlashAttribute("settings_toast", result);
 
-        return "redirect:/credentialsSettings.view";
+        return "redirect:/credentialsSettings.view" + (credOwner.equals(user.getName()) ? "" : "?username=" + credOwner);
+    }
+
+    private String resolveTargetUsername(Authentication user, String targetUsername) {
+        if (targetUsername == null || targetUsername.isBlank()) {
+            return user.getName();
+        }
+        User userInDb = securityService.getUserByName(user.getName());
+        if (userInDb != null && userInDb.isAdminRole()) {
+            User target = securityService.getUserByName(targetUsername);
+            if (target != null) {
+                return target.getUsername();
+            }
+        }
+        return user.getName();
     }
 
     @PostMapping(path = "/admin")

--- a/airsonic-main/src/main/resources/templates/credentialsSettings.html
+++ b/airsonic-main/src/main/resources/templates/credentialsSettings.html
@@ -114,9 +114,24 @@
 <th:block th:replace="~{settingsHeader::header(cat='credentials',toast=${settings_toast},restricted=${!adminRole})}" />
 
 <h2>Credentials Management</h2>
+
+<th:block th:if="${adminRole}">
+<div style="margin-bottom:1em">
+  <form method="get" th:action="@{/credentialsSettings.view}" style="display:inline">
+    <label>Viewing credentials for:
+      <select name="username" onchange="this.form.submit()">
+        <option th:each="u:${allUsernames}" th:value="${u}" th:text="${u}"
+                th:selected="${u == targetUsername}"></option>
+      </select>
+    </label>
+  </form>
+</div>
+</th:block>
+
 <div>
-<h3>Credentials</h3>
+<h3>Credentials for <span th:text="${targetUsername}"></span></h3>
 <form method="post" th:action="@{/credentialsSettings/update}" th:object="${command}">
+  <input type="hidden" name="targetUsername" th:value="${targetUsername}"/>
 
   <table id="credentialsTable">
   <tr>
@@ -234,6 +249,7 @@
 
 <div id="createNewCreds" style="display:none">
   <form method="post" th:action="@{/credentialsSettings.view}" id="newCreds" th:object="${newCreds}">
+    <input type="hidden" name="targetUsername" th:value="${targetUsername}"/>
 
     <table style="white-space:nowrap" class="indent">
       <tr>

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/CredentialsManagementControllerTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/CredentialsManagementControllerTest.java
@@ -1,0 +1,123 @@
+package org.airsonic.player.controller;
+
+import org.airsonic.player.command.CredentialsManagementCommand.CredentialsCommand;
+import org.airsonic.player.domain.User;
+import org.airsonic.player.domain.User.Role;
+import org.airsonic.player.service.SecurityService;
+import org.airsonic.player.service.SettingsService;
+import org.airsonic.player.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+
+import java.util.EnumSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for the admin user selector fix: admins can view/edit credentials for
+ * any user via the ?username= query parameter. Non-admins are restricted to
+ * their own credentials regardless of the parameter value.
+ */
+@ExtendWith(MockitoExtension.class)
+class CredentialsManagementControllerTest {
+
+    @Mock
+    private SecurityService securityService;
+    @Mock
+    private SettingsService settingsService;
+    @Mock
+    private UserService userService;
+    @Mock
+    private Authentication auth;
+    @Mock
+    private BindingResult bindingResult;
+
+    @InjectMocks
+    private CredentialsManagementController controller;
+
+    private User adminUser;
+    private User regularUser;
+    private User otherUser;
+
+    @BeforeEach
+    void setUp() {
+        adminUser = new User("admin", null, false, 0, 0, 0, EnumSet.of(Role.ADMIN));
+        regularUser = new User("alice", null, false, 0, 0, 0, EnumSet.noneOf(Role.class));
+        otherUser = new User("bob", null, false, 0, 0, 0, EnumSet.noneOf(Role.class));
+        when(bindingResult.hasErrors()).thenReturn(false);
+    }
+
+    @Test
+    void adminTargetingKnownUser_redirectIncludesTargetUsername() {
+        when(auth.getName()).thenReturn("admin");
+        when(securityService.getUserByName("admin")).thenReturn(adminUser);
+        when(securityService.getUserByName("bob")).thenReturn(otherUser);
+        when(securityService.createCredential(eq("bob"), any(), any())).thenReturn(true);
+
+        String redirect = controller.createNewCreds(auth, new CredentialsCommand(),
+                bindingResult, new RedirectAttributesModelMap(), new ModelMap(), "bob");
+
+        assertThat(redirect).contains("?username=bob");
+    }
+
+    @Test
+    void nonAdminWithTargetUsername_redirectOmitsUsername() {
+        when(auth.getName()).thenReturn("alice");
+        when(securityService.getUserByName("alice")).thenReturn(regularUser);
+        when(securityService.createCredential(eq("alice"), any(), any())).thenReturn(true);
+
+        String redirect = controller.createNewCreds(auth, new CredentialsCommand(),
+                bindingResult, new RedirectAttributesModelMap(), new ModelMap(), "bob");
+
+        assertThat(redirect).doesNotContain("username=");
+    }
+
+    @Test
+    void adminTargetingUnknownUser_fallsBackToOwnRedirect() {
+        when(auth.getName()).thenReturn("admin");
+        when(securityService.getUserByName("admin")).thenReturn(adminUser);
+        when(securityService.getUserByName("nobody")).thenReturn(null);
+        when(securityService.createCredential(eq("admin"), any(), any())).thenReturn(true);
+
+        String redirect = controller.createNewCreds(auth, new CredentialsCommand(),
+                bindingResult, new RedirectAttributesModelMap(), new ModelMap(), "nobody");
+
+        assertThat(redirect).doesNotContain("username=");
+    }
+
+    @Test
+    void nullTargetUsername_usesAuthenticatedUser() {
+        when(auth.getName()).thenReturn("alice");
+        // resolveTargetUsername returns early for null — getUserByName is never called
+        when(securityService.createCredential(eq("alice"), any(), any())).thenReturn(true);
+
+        String redirect = controller.createNewCreds(auth, new CredentialsCommand(),
+                bindingResult, new RedirectAttributesModelMap(), new ModelMap(), null);
+
+        assertThat(redirect).doesNotContain("username=");
+    }
+
+    @Test
+    void blankTargetUsername_usesAuthenticatedUser() {
+        when(auth.getName()).thenReturn("alice");
+        // resolveTargetUsername returns early for blank — getUserByName is never called
+        when(securityService.createCredential(eq("alice"), any(), any())).thenReturn(true);
+
+        String redirect = controller.createNewCreds(auth, new CredentialsCommand(),
+                bindingResult, new RedirectAttributesModelMap(), new ModelMap(), "   ");
+
+        // blank param treated same as null — targets own user, no ?username= suffix
+        assertThat(redirect).doesNotContain("username=");
+    }
+}


### PR DESCRIPTION
## Summary

- The Credentials page previously showed only the logged-in user's own credentials with no way to select another user
- Admins who added credentials for other users via the Users tab could not see or manage those credentials from the Credentials page
- Adds \`?username=X\` query parameter support (admin-only) to load any user's credentials
- Adds a dropdown user selector visible to admins so they can switch between users without navigating away
- POST forms (create/update) carry a \`targetUsername\` hidden field so actions apply to the selected user

## Test plan

- [ ] Non-admin: Credentials page shows only own credentials, no user selector visible
- [ ] Admin: Credentials page shows a user dropdown; selecting a user reloads the page for that user's credentials
- [ ] Admin: credentials added via Users tab for user X are visible at \`credentialsSettings.view?username=X\`
- [ ] Admin: can update encoder / delete credentials for another user's credentials
- [ ] Admin: \`?username=nonexistent\` falls back to showing admin's own credentials

Fixes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)