### PR TITLE
fix: use original username for avatar URL in now playing bar

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/NowPlayingController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/NowPlayingController.java
@@ -122,7 +122,10 @@ public class NowPlayingController {
         boolean hasCustomAvatar = userSettings.getAvatarScheme() == AvatarScheme.CUSTOM
                 && personalSettingsService.getCustomAvatar(username) != null;
 
-        // generate display name
+        // avatarUsername stays as the real Airsonic username for avatar URL lookups
+        String avatarUsername = username;
+
+        // generate display name (may include player name for external players)
         if (StringUtils.isNotBlank(player.getName())) {
             username += "@" + player.getName();
         }
@@ -136,6 +139,7 @@ public class NowPlayingController {
             player.getId(),
             mediaFile.getId(),
             username,
+            avatarUsername,
             artist,
             title,
             minutesAgo,

--- a/airsonic-main/src/main/java/org/airsonic/player/view/NowPlayingView.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/view/NowPlayingView.java
@@ -33,6 +33,7 @@ public class NowPlayingView {
     private final Integer mediaFileId;
 
     private final String username;
+    private final String avatarUsername;
     private final String artist;
     private final String title;
     private final long minutesAgo;
@@ -43,13 +44,14 @@ public class NowPlayingView {
     private final boolean hasCustomAvatar;
 
     public NowPlayingView(UUID transferId, Integer playerId, Integer mediaFileId,
-            String username, String artist, String title, long minutesAgo,
+            String username, String avatarUsername, String artist, String title, long minutesAgo,
             boolean showLyrics, String avatarScheme, Integer systemAvatarId,
             boolean hasCustomAvatar) {
         this.transferId = transferId;
         this.playerId = playerId;
         this.mediaFileId = mediaFileId;
         this.username = username;
+        this.avatarUsername = avatarUsername;
         this.artist = artist;
         this.title = title;
         this.minutesAgo = minutesAgo;
@@ -73,6 +75,10 @@ public class NowPlayingView {
 
     public String getUsername() {
         return username;
+    }
+
+    public String getAvatarUsername() {
+        return avatarUsername;
     }
 
     public String getArtist() {

--- a/airsonic-main/src/main/resources/templates/nowplaying/_status.html
+++ b/airsonic-main/src/main/resources/templates/nowplaying/_status.html
@@ -11,7 +11,7 @@
 
                 <img th:if="${np.avatarScheme == 'CUSTOM' and np.hasCustomAvatar}"
                          alt="Avatar"
-                         th:src="@{/avatar.view(username=${np.username})}"
+                         th:src="@{/avatar.view(username=${np.avatarUsername})}"
                          style="padding-right:5pt;width:30px;height:30px"/>
 
                 <b th:text="${np.username}"></b>

--- a/airsonic-main/src/test/java/org/airsonic/player/controller/NowPlayingControllerTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/controller/NowPlayingControllerTest.java
@@ -109,11 +109,48 @@ public class NowPlayingControllerTest {
         assertEquals(5L, view.getMinutesAgo());
         assertEquals(AvatarScheme.NONE.name(), view.getAvatarScheme());
         assertEquals(TEST_USER + "@" + player.getName(), view.getUsername());
+        // avatarUsername must remain the original username, not the display name with "@player"
+        assertEquals(TEST_USER, view.getAvatarUsername());
         // Since mediaFile is not a video, lyrics should be shown.
         assertTrue(view.isShowLyrics());
         // Since AvatarScheme.NONE is set in userSettings, no custom avatar should be present.
         assertFalse(view.hasCustomAvatar());
 
+    }
+
+    @Test
+    @WithMockUser(username = TEST_USER, password = TEST_PASSWORD)
+    public void testAvatarUrlUsesOriginalUsername() throws Exception {
+        UUID id = UUID.randomUUID();
+        Player player = new Player();
+        player.setId(20);
+        player.setName("ExternalPlayer");
+        player.setUsername(TEST_USER);
+
+        when(playStatus.getTransferId()).thenReturn(id);
+        when(playStatus.getPlayer()).thenReturn(player);
+        when(playStatus.getMediaFile()).thenReturn(mediaFile);
+        when(playStatus.getMinutesAgo()).thenReturn(2L);
+        when(mediaFile.getId()).thenReturn(30);
+        when(mediaFile.isVideo()).thenReturn(false);
+        when(mediaFile.getArtist()).thenReturn("Artist");
+        when(mediaFile.getTitle()).thenReturn("Title");
+        when(userSettings.getAvatarScheme()).thenReturn(AvatarScheme.NONE);
+        when(personalSettingsService.getUserSettings(TEST_USER)).thenReturn(userSettings);
+        when(statusService.getActivePlayStatuses()).thenReturn(List.of(playStatus));
+        when(statusService.getInactivePlayStatuses()).thenReturn(List.of());
+
+        NowPlayingView view = (NowPlayingView) mvc.perform(get("/nowPlaying/status").param("id", id.toString()))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getModelAndView()
+                .getModel()
+                .get("np");
+
+        // display name gets player suffix appended
+        assertEquals(TEST_USER + "@ExternalPlayer", view.getUsername());
+        // avatar URL lookup must use the unmodified username, not the display name
+        assertEquals(TEST_USER, view.getAvatarUsername());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- When an external player (e.g. DSub) is active, the display name is formatted as \`user@PlayerName\` to indicate which player is in use
- The custom avatar URL was using this display string as the \`username\` parameter to \`/avatar.view\`, causing a 404 and showing only the alt text instead of the avatar image
- Add \`avatarUsername\` field to \`NowPlayingView\` holding the original Airsonic username (before the \`@PlayerName\` suffix is appended)
- Use \`avatarUsername\` in the now-playing status template for the avatar endpoint call

## Test plan

- [ ] Web player (no player name): avatar loads correctly as before
- [ ] External player (DSub/BubbleUPnP/etc with a player name): avatar image loads correctly in the now playing and recently played bars
- [ ] SYSTEM avatar: still resolves via \`/avatar.view?id=X\` (unchanged)
- [ ] CUSTOM avatar: resolves via \`/avatar.view?username=<actual-username>\` (fixed)
- [ ] Display name still shows \`user@PlayerName\` in the now playing bar

Fixes #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)