### PR TITLE
fix: debounce 'Now Playing' status to prevent flash from stream probes

### DIFF
--- a/airsonic-main/src/main/resources/templates/right.html
+++ b/airsonic-main/src/main/resources/templates/right.html
@@ -59,10 +59,27 @@
                     // no need to populate initial because the updates will occur frequently enough and are self-sufficient
                     '/topic/scanStatus': scanningStatus,
                     '/topic/nowPlaying/current/add': function (msg) {
-                        enqueueAdd(JSON.parse(msg.body), 'nowPlaying');
+                        const status = JSON.parse(msg.body);
+                        // Debounce: wait 2 seconds before adding to the now-playing table.
+                        // Probes from external players (e.g. DSub) open and close the stream
+                        // within milliseconds; debouncing prevents a "Now Playing" flash that
+                        // is immediately replaced by "Recently Played".
+                        if (nowPlayingPendingAdds[status.transferId]) {
+                            clearTimeout(nowPlayingPendingAdds[status.transferId]);
+                        }
+                        nowPlayingPendingAdds[status.transferId] = setTimeout(function() {
+                            delete nowPlayingPendingAdds[status.transferId];
+                            enqueueAdd(status, 'nowPlaying');
+                        }, 2000);
                     },
                     '/topic/nowPlaying/current/remove': function (msg) {
-                        enqueueRemove(JSON.parse(msg.body), 'nowPlaying');
+                        const status = JSON.parse(msg.body);
+                        // Cancel any pending debounced add for this transfer
+                        if (nowPlayingPendingAdds[status.transferId]) {
+                            clearTimeout(nowPlayingPendingAdds[status.transferId]);
+                            delete nowPlayingPendingAdds[status.transferId];
+                        }
+                        enqueueRemove(status, 'nowPlaying');
                     },
                     '/topic/nowPlaying/recent/add': function (msg) {
                         enqueueAdd(JSON.parse(msg.body), 'recentlyPlayed');
@@ -95,6 +112,7 @@
         }
 
         const queue = new TaskQueue();
+        const nowPlayingPendingAdds = {};
 
         function enqueueAdd(status, table) {
           return queue.enqueue(() => addStatus(status, table));


### PR DESCRIPTION
## Summary

- External players (e.g. DSub) probe the stream by opening it briefly, then closing immediately
- This caused \`fileStartListener\` → \`addActiveLocalPlay\` → \`current/add\` broadcast, followed immediately by \`removeActiveLocalPlay\` → \`current/remove\` → \`removeStreamStatus\` → \`recent/add\`
- The client would briefly show "Now Playing" (for the duration of one HTTP fetch) before it disappeared and "Recently Played" appeared instead
- Add a 2-second client-side debounce on \`current/add\` messages: if \`current/remove\` arrives before the timeout fires, the pending "Now Playing" entry is cancelled and never shown
- Legitimate playback (>2 seconds) is unaffected — the entry appears in "Now Playing" after the debounce window

## Test plan

- [ ] Start playing a track in the web player — "Now Playing" appears within ~2 seconds
- [ ] Use DSub or another external player to connect — "Now Playing" does NOT briefly flash before "Recently Played" appears
- [ ] Skip to next track — "Now Playing" updates after debounce, previous track moves to "Recently Played"
- [ ] Stop playback — "Now Playing" disappears, "Recently Played" shows

Fixes #592
Related to #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)