### PR TITLE
fix: read embedded id3 USLT lyrics tags as a lyrics source

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/LyricsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/LyricsService.java
@@ -8,6 +8,11 @@ import org.airsonic.player.parser.lyrics.LrcParser;
 import org.airsonic.player.parser.lyrics.LyricsLine;
 import org.airsonic.player.repository.LyricsRepository;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
+import org.jaudiotagger.audio.AudioFile;
+import org.jaudiotagger.audio.AudioFileIO;
+import org.jaudiotagger.tag.FieldKey;
+import org.jaudiotagger.tag.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -72,21 +77,38 @@ public class LyricsService {
                 targetLrcPath = lrcPath;
             } else if (Files.exists(lrcPathUpper)) {
                 targetLrcPath = lrcPathUpper;
-            } else {
-                LOG.debug("LRC file does not exist for media: {}", mediaFile.getId());
-                return null;
             }
-            LrcFile lrcFile = lrcParser.parse(targetLrcPath);
-            if (lrcFile == null || lrcFile.getLyricsLines().isEmpty()) {
+
+            if (targetLrcPath != null) {
+                LrcFile lrcFile = lrcParser.parse(targetLrcPath);
+                if (lrcFile != null && !lrcFile.getLyricsLines().isEmpty()) {
+                    StringBuilder lyricsText = new StringBuilder();
+                    for (LyricsLine line : lrcFile.getLyricsLines()) {
+                        lyricsText.append(line.getText()).append("\n");
+                    }
+                    Lyrics newLyrics = new Lyrics(lyricsText.toString(), mediaFile.getId(), "file");
+                    return lyricsRepository.save(newLyrics);
+                }
                 LOG.debug("No lyrics found in LRC file: {}", targetLrcPath);
-                return null;
             }
-            StringBuilder lyricsText = new StringBuilder();
-            for (LyricsLine line : lrcFile.getLyricsLines()) {
-                lyricsText.append(line.getText()).append("\n");
+
+            // Fall back to embedded id3 USLT tag via jaudiotagger
+            try {
+                AudioFile audioFile = AudioFileIO.read(filePath.toFile());
+                Tag tag = audioFile.getTag();
+                if (tag != null) {
+                    String embedded = StringUtils.trimToNull(tag.getFirst(FieldKey.LYRICS));
+                    if (embedded != null) {
+                        Lyrics newLyrics = new Lyrics(embedded, mediaFile.getId(), "tag");
+                        return lyricsRepository.save(newLyrics);
+                    }
+                }
+            } catch (Exception e) {
+                LOG.warn("Failed to read embedded lyrics tag from {}: {}", filePath, e.getMessage());
             }
-            Lyrics newLyrics = new Lyrics(lyricsText.toString(), mediaFile.getId(), "file");
-            return lyricsRepository.save(newLyrics);
+
+            LOG.debug("No lyrics found for media: {}", mediaFile.getId());
+            return null;
         });
 
     }

--- a/airsonic-main/src/test/java/org/airsonic/player/service/LyricsServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/LyricsServiceTest.java
@@ -4,6 +4,10 @@ import org.airsonic.player.domain.Lyrics;
 import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.repository.LyricsRepository;
 import org.airsonic.player.util.MusicFolderTestData;
+import org.jaudiotagger.audio.AudioFile;
+import org.jaudiotagger.audio.AudioFileIO;
+import org.jaudiotagger.tag.FieldKey;
+import org.jaudiotagger.tag.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -11,8 +15,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -114,6 +120,60 @@ class LyricsServiceTest {
         assertNotNull(result.getCreated());
         assertNotNull(result.getUpdated());
 
+    }
+
+    @Test
+    void getLyricsFromMediaFile_shouldReadEmbeddedUsltTagWhenNoLrcFile() {
+        Path path = Path.of("nonexistent.mp3");
+        when(mediaFile.isDirectory()).thenReturn(false);
+        when(mediaFile.isIndexedTrack()).thenReturn(false);
+        when(mediaFile.getId()).thenReturn(5);
+        when(mediaFile.getFullPath()).thenReturn(path);
+        when(lyricsRepository.findByMediaFileId(eq(5))).thenReturn(Optional.empty());
+        when(lyricsRepository.save(any(Lyrics.class))).thenAnswer(i -> i.getArgument(0));
+
+        AudioFile mockAudioFile = mock(AudioFile.class);
+        Tag mockTag = mock(Tag.class);
+        when(mockAudioFile.getTag()).thenReturn(mockTag);
+        when(mockTag.getFirst(FieldKey.LYRICS)).thenReturn("Embedded lyrics text");
+
+        try (MockedStatic<AudioFileIO> mocked = mockStatic(AudioFileIO.class)) {
+            mocked.when(() -> AudioFileIO.read(any(File.class))).thenReturn(mockAudioFile);
+
+            Lyrics result = lyricsService.getLyricsFromMediaFile(mediaFile);
+
+            assertNotNull(result);
+            assertEquals("Embedded lyrics text", result.getLyrics());
+            assertEquals(5, result.getMediaFileId());
+            assertEquals("tag", result.getSource());
+            ArgumentCaptor<Lyrics> captor = ArgumentCaptor.forClass(Lyrics.class);
+            verify(lyricsRepository).save(captor.capture());
+            assertEquals("tag", captor.getValue().getSource());
+        }
+    }
+
+    @Test
+    void getLyricsFromMediaFile_shouldReturnNullWhenTagHasNoLyrics() {
+        Path path = Path.of("nonexistent.mp3");
+        when(mediaFile.isDirectory()).thenReturn(false);
+        when(mediaFile.isIndexedTrack()).thenReturn(false);
+        when(mediaFile.getId()).thenReturn(6);
+        when(mediaFile.getFullPath()).thenReturn(path);
+        when(lyricsRepository.findByMediaFileId(eq(6))).thenReturn(Optional.empty());
+
+        AudioFile mockAudioFile = mock(AudioFile.class);
+        Tag mockTag = mock(Tag.class);
+        when(mockAudioFile.getTag()).thenReturn(mockTag);
+        when(mockTag.getFirst(FieldKey.LYRICS)).thenReturn("  "); // blank
+
+        try (MockedStatic<AudioFileIO> mocked = mockStatic(AudioFileIO.class)) {
+            mocked.when(() -> AudioFileIO.read(any(File.class))).thenReturn(mockAudioFile);
+
+            Lyrics result = lyricsService.getLyricsFromMediaFile(mediaFile);
+
+            assertNull(result);
+            verify(lyricsRepository, never()).save(any());
+        }
     }
 
     @Test


### PR DESCRIPTION
## Problem

When browsing lyrics for a track, Airsonic only checks the database and `.lrc`
sidecar files. Audio files with lyrics embedded as id3 USLT (Unsynchronised
Lyrics/Text) tags — the standard mechanism in MP3/FLAC/OGG files — were
silently ignored.

Closes #582

## Fix

Add a third fallback in `LyricsService.getLyricsFromMediaFile()`: after the
sidecar check fails, open the audio file with jaudiotagger (already a project
dependency) and read `FieldKey.LYRICS`. When a non-blank value is found, it is
persisted to the database via `lyricsRepository` so subsequent lookups are
served from the DB without re-reading the file. Source is set to `"tag"` to
distinguish from `"file"` (sidecar) entries.

Failure to read the tag (unsupported format, corrupt file) is caught and
logged at WARN level; the method continues to return null, preserving
existing behaviour.

## Tests

Added two tests to `LyricsServiceTest`:
- `getLyricsFromMediaFile_shouldReadEmbeddedUsltTagWhenNoLrcFile` — verifies embedded lyrics are read and persisted with source `"tag"`
- `getLyricsFromMediaFile_shouldReturnNullWhenTagHasNoLyrics` — verifies blank/missing tag returns null without saving

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>